### PR TITLE
fix: improve parallel execution test stability

### DIFF
--- a/test/fixtures/parallel_tasks.rb
+++ b/test/fixtures/parallel_tasks.rb
@@ -170,11 +170,37 @@ class SequentialTaskD < Taski::Task
 end
 
 # Test fixtures for parallel chain execution
+# Module to track start times for verifying parallel execution
+module ParallelChainStartTimes
+  @start_times = {}
+  @mutex = Mutex.new
+
+  class << self
+    def record(task_name)
+      @mutex.synchronize do
+        @start_times[task_name] = Time.now
+      end
+    end
+
+    def get(task_name)
+      @mutex.synchronize do
+        @start_times[task_name]
+      end
+    end
+
+    def reset
+      @mutex.synchronize do
+        @start_times = {}
+      end
+    end
+  end
+end
 
 class ParallelChain1A < Taski::Task
   exports :value
 
   def run
+    ParallelChainStartTimes.record(:chain1a)
     sleep(0.1)
     @value = "Chain1-A"
   end
@@ -193,6 +219,7 @@ class ParallelChain2C < Taski::Task
   exports :value
 
   def run
+    ParallelChainStartTimes.record(:chain2c)
     sleep(0.1)
     @value = "Chain2-C"
   end


### PR DESCRIPTION
## Summary
- Replace timing-based assertion with start time comparison
- The previous test checked total execution time which was unreliable on slow environments like debug Ruby builds
- Now verify parallel execution by comparing start times of independent task chains

## Changes
- Add `ParallelChainStartTimes` module to track when each chain starts
- Update test to assert that independent chains start nearly simultaneously (< 50ms difference)

## Test plan
- [ ] CI passes on all Ruby versions including debug build

🤖 Generated with [Claude Code](https://claude.com/claude-code)