### PR TITLE
test: improve test coverage from 88.87% to 90.73%

### DIFF
--- a/test/test_parallel_progress_display.rb
+++ b/test/test_parallel_progress_display.rb
@@ -166,4 +166,43 @@ class TestParallelProgressDisplay < Minitest::Test
     assert_includes result, "TaskA"
     assert_includes result, "TaskB"
   end
+
+  # Test Taski.reset_progress_display!
+  def test_taski_reset_progress_display
+    # First, enable progress by setting the environment variable
+    original_env = ENV["TASKI_FORCE_PROGRESS"]
+    ENV["TASKI_FORCE_PROGRESS"] = "1"
+
+    # Reset any existing progress display
+    Taski.reset_progress_display!
+
+    # Access progress_display to create a new one
+    display = Taski.progress_display
+    assert_instance_of Taski::Execution::ParallelProgressDisplay, display
+
+    # Reset should clear it
+    Taski.reset_progress_display!
+
+    # Accessing again should create a new instance
+    new_display = Taski.progress_display
+    refute_same display, new_display
+  ensure
+    ENV["TASKI_FORCE_PROGRESS"] = original_env
+    Taski.reset_progress_display!
+  end
+
+  # Test progress_display returns nil when disabled
+  def test_taski_progress_display_returns_nil_when_disabled
+    original_env = ENV["TASKI_PROGRESS"]
+    original_force = ENV["TASKI_FORCE_PROGRESS"]
+    ENV["TASKI_PROGRESS"] = nil
+    ENV["TASKI_FORCE_PROGRESS"] = nil
+
+    Taski.reset_progress_display!
+    assert_nil Taski.progress_display
+  ensure
+    ENV["TASKI_PROGRESS"] = original_env
+    ENV["TASKI_FORCE_PROGRESS"] = original_force
+    Taski.reset_progress_display!
+  end
 end

--- a/test/test_section.rb
+++ b/test/test_section.rb
@@ -38,4 +38,40 @@ class TestSection < Minitest::Test
   def test_external_impl_has_explicit_exports
     assert_equal [:value], ExternalImpl.exported_methods
   end
+
+  # Test Section#impl raises NotImplementedError when not overridden
+  def test_section_impl_raises_not_implemented_error
+    section_class = Class.new(Taski::Section) do
+      interfaces :value
+    end
+
+    # Directly instantiate and call impl to test the error
+    section_instance = section_class.allocate
+    section_instance.send(:initialize)
+
+    error = assert_raises(NotImplementedError) do
+      section_instance.impl
+    end
+    assert_match(/Subclasses must implement the impl method/, error.message)
+  end
+
+  # Test Section with nil impl raises error in run
+  def test_section_run_with_nil_impl_raises_error
+    section_class = Class.new(Taski::Section) do
+      interfaces :value
+
+      def impl
+        nil
+      end
+    end
+
+    # Directly instantiate and call run to test the error
+    section_instance = section_class.allocate
+    section_instance.send(:initialize)
+
+    error = assert_raises(RuntimeError) do
+      section_instance.run
+    end
+    assert_match(/does not have an implementation/, error.message)
+  end
 end


### PR DESCRIPTION
## Summary
- Add tests for previously uncovered error paths and edge cases
- Coverage improved from 88.87% to 90.73%

## Changes
- `test/test_parallel_execution.rb`: Task#run NotImplementedError, Task instance reset!, Registry#get_task error
- `test/test_parallel_progress_display.rb`: Taski.reset_progress_display!, progress_display returns nil when disabled
- `test/test_section.rb`: Section#impl NotImplementedError, Section#run with nil impl error

## Test plan
- [x] All 72 tests pass
- [x] Coverage increased to 90.73%
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)