### PR TITLE
test: add nested Section test case

### DIFF
--- a/test/fixtures/parallel_tasks.rb
+++ b/test/fixtures/parallel_tasks.rb
@@ -338,3 +338,30 @@ class ExternalImpl < Taski::Task
     @value = "external implementation"
   end
 end
+
+# Test fixtures for nested Section (Section inside Section)
+# OuterSection's impl returns InnerSection (which is also a Section)
+
+class InnerSection < Taski::Section
+  interfaces :db_url
+
+  class InnerImpl < Taski::Task
+    exports :db_url
+
+    def run
+      @db_url = "postgres://localhost:5432/mydb"
+    end
+  end
+
+  def impl
+    InnerImpl
+  end
+end
+
+class OuterSection < Taski::Section
+  interfaces :db_url
+
+  def impl
+    InnerSection
+  end
+end

--- a/test/test_section.rb
+++ b/test/test_section.rb
@@ -74,4 +74,16 @@ class TestSection < Minitest::Test
     end
     assert_match(/does not have an implementation/, error.message)
   end
+
+  # Test nested Section (Section inside Section)
+  # OuterSection uses InnerSection as impl, which is also a Section
+  def test_nested_section_inside_section
+    OuterSection.run
+
+    # OuterSection should have the value from InnerSection
+    assert_equal "postgres://localhost:5432/mydb", OuterSection.db_url
+
+    # InnerSection should also be executed and have the same value
+    assert_equal "postgres://localhost:5432/mydb", InnerSection.db_url
+  end
 end


### PR DESCRIPTION
## Summary
- Add test to verify that Section can use another Section as its implementation
- Add fixtures for `InnerSection` and `OuterSection` to demonstrate nested Section pattern

## Test plan
- [x] `rake test` passes (73 tests, 223 assertions)
- [x] `rake standard` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)