### PR TITLE
feat: enhance tree display with type labels and colors

### DIFF
--- a/lib/taski/static_analysis/analyzer.rb
+++ b/lib/taski/static_analysis/analyzer.rb
@@ -9,26 +9,38 @@ module Taski
       # @param task_class [Class] The task class to analyze
       # @return [Set<Class>] Set of task classes that are dependencies
       def self.analyze(task_class)
-        source_location = extract_run_method_location(task_class)
+        target_method = target_method_for(task_class)
+        source_location = extract_method_location(task_class, target_method)
         return Set.new unless source_location
 
         file_path, _line_number = source_location
         parse_result = Prism.parse_file(file_path)
 
-        visitor = Visitor.new(task_class)
+        visitor = Visitor.new(task_class, target_method)
         visitor.visit(parse_result.value)
         visitor.dependencies
       end
 
       # @param task_class [Class] The task class
+      # @return [Symbol] The method name to analyze (:run for Task, :impl for Section)
+      def self.target_method_for(task_class)
+        if defined?(Taski::Section) && task_class < Taski::Section
+          :impl
+        else
+          :run
+        end
+      end
+
+      # @param task_class [Class] The task class
+      # @param method_name [Symbol] The method name to extract location for
       # @return [Array<String, Integer>, nil] File path and line number, or nil
-      def self.extract_run_method_location(task_class)
-        task_class.instance_method(:run).source_location
+      def self.extract_method_location(task_class, method_name)
+        task_class.instance_method(method_name).source_location
       rescue NameError
         nil
       end
 
-      private_class_method :extract_run_method_location
+      private_class_method :target_method_for, :extract_method_location
     end
   end
 end

--- a/test/test_tree_display.rb
+++ b/test/test_tree_display.rb
@@ -4,6 +4,11 @@ require "test_helper"
 require_relative "fixtures/parallel_tasks"
 
 class TestTreeDisplay < Minitest::Test
+  # Remove ANSI color codes for testing
+  def strip_ansi(str)
+    str.gsub(/\e\[[0-9;]*m/, "")
+  end
+
   def test_tree_method_exists
     assert_respond_to FixtureTaskA, :tree
   end
@@ -39,5 +44,42 @@ class TestTreeDisplay < Minitest::Test
     assert_includes result, "DeepDependency::TaskF"
     assert_includes result, "DeepDependency::TaskD"
     assert_includes result, "ParallelTaskC"
+  end
+
+  def test_tree_shows_type_label_for_task
+    result = FixtureTaskA.tree
+    assert_includes result, "(Task)"
+  end
+
+  def test_tree_shows_type_label_for_section
+    result = NestedSection.tree
+    assert_includes result, "(Section)"
+  end
+
+  def test_tree_shows_impl_prefix_for_section_dependency
+    result = NestedSection.tree
+    assert_includes result, "[impl]"
+    assert_includes result, "NestedSection::LocalDB"
+  end
+
+  def test_tree_shows_nested_section_with_impl
+    result = strip_ansi(OuterSection.tree)
+    assert_includes result, "OuterSection (Section)"
+    assert_includes result, "[impl] InnerSection (Section)"
+    assert_includes result, "[impl] InnerSection::InnerImpl (Task)"
+  end
+
+  def test_tree_shows_mixed_task_and_section_dependencies
+    result = strip_ansi(DeepDependency::TaskD.tree)
+    assert_includes result, "DeepDependency::TaskD (Task)"
+    assert_includes result, "ParallelTaskC (Task)"
+    assert_includes result, "ParallelSection (Section)"
+    assert_includes result, "[impl] ParallelSectionImpl2 (Task)"
+  end
+
+  def test_tree_includes_ansi_color_codes
+    result = FixtureTaskA.tree
+    # Check that ANSI codes are present
+    assert_match(/\e\[/, result)
   end
 end


### PR DESCRIPTION
## Summary
- Add `(Task)` and `(Section)` type labels to tree output for better clarity
- Add `[impl]` prefix to show Section implementation dependencies
- Add ANSI color codes for visual distinction (bold names, green Task, blue Section, yellow impl, gray tree lines)
- Extend static analysis to parse Section's `impl` method

## Example Output
```
OuterSection (Section)
└── [impl] InnerSection (Section)
    └── [impl] InnerSection::InnerImpl (Task)
```

## Test plan
- [x] Existing tree display tests pass
- [x] New tests for type labels added
- [x] New tests for Section impl display added
- [x] New test for ANSI color codes added
- [x] `rake test` passes (79 tests, 247 assertions)
- [x] `rake standard` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)