### PR TITLE
feat: refactor Context to instance-based design with user options

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,19 +115,36 @@ end
 
 ## Advanced Usage
 
-### Context - Runtime Information
+### Context - Runtime Information and Options
 
-Access execution context from any task:
+Pass custom options and access execution context from any task:
 
 ```ruby
 class DeployTask < Taski::Task
   def run
-    puts "Working directory: #{Taski::Context.working_directory}"
-    puts "Started at: #{Taski::Context.started_at}"
-    puts "Root task: #{Taski::Context.root_task}"
+    # User-defined options
+    env = Taski.context[:env]
+    debug = Taski.context.fetch(:debug, false)
+
+    # Runtime information
+    puts "Working directory: #{Taski.context.working_directory}"
+    puts "Started at: #{Taski.context.started_at}"
+    puts "Root task: #{Taski.context.root_task}"
+    puts "Deploying to: #{env}"
   end
 end
+
+# Pass options when running
+DeployTask.run(context: { env: "production", debug: true })
 ```
+
+Context API:
+- `Taski.context[:key]` - Get option value (nil if not set)
+- `Taski.context.fetch(:key, default)` - Get with default value
+- `Taski.context.key?(:key)` - Check if option exists
+- `Taski.context.working_directory` - Execution directory
+- `Taski.context.started_at` - Execution start time
+- `Taski.context.root_task` - First task class called
 
 ### Re-execution
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,18 +34,21 @@ ruby examples/section_demo.rb
 
 ---
 
-### 3. context_demo.rb - Runtime Context
+### 3. context_demo.rb - Runtime Context and Options
 
-Access execution context information from any task.
+Access execution context and pass custom options to tasks.
 
 ```bash
 ruby examples/context_demo.rb
 ```
 
 **Covers:**
-- `Taski::Context.working_directory`
-- `Taski::Context.started_at`
-- `Taski::Context.root_task`
+- User-defined options via `run(context: {...})`
+- `Taski.context[:key]` for option access
+- `Taski.context.fetch(:key, default)` for defaults
+- `Taski.context.working_directory`
+- `Taski.context.started_at`
+- `Taski.context.root_task`
 
 ---
 

--- a/lib/taski.rb
+++ b/lib/taski.rb
@@ -28,6 +28,29 @@ module Taski
     end
   end
 
+  @context_monitor = Monitor.new
+
+  # Get the current execution context
+  # @return [Context, nil] The current context or nil if no task is running
+  def self.context
+    @context_monitor.synchronize { @context }
+  end
+
+  # Start a new execution context (internal use only)
+  # @api private
+  def self.start_context(options:, root_task:)
+    @context_monitor.synchronize do
+      return if @context
+      @context = Context.new(options: options, root_task: root_task)
+    end
+  end
+
+  # Reset the execution context (internal use only)
+  # @api private
+  def self.reset_context!
+    @context_monitor.synchronize { @context = nil }
+  end
+
   def self.global_registry
     @global_registry ||= Execution::Registry.new
   end

--- a/lib/taski/task.rb
+++ b/lib/taski/task.rb
@@ -39,14 +39,14 @@ module Taski
         @dependencies_cache = nil
       end
 
-      def run
-        Taski::Context.set_root_task(self)
+      def run(context: {})
+        Taski.start_context(options: context, root_task: self)
         validate_no_circular_dependencies!
         cached_wrapper.run
       end
 
-      def clean
-        Taski::Context.set_root_task(self)
+      def clean(context: {})
+        Taski.start_context(options: context, root_task: self)
         validate_no_circular_dependencies!
         cached_wrapper.clean
       end
@@ -65,7 +65,7 @@ module Taski
       def reset!
         registry.reset!
         Taski.reset_global_registry!
-        Taski::Context.reset!
+        Taski.reset_context!
         @coordinator = nil
         @circular_dependency_checked = false
       end
@@ -163,7 +163,7 @@ module Taski
         singleton_class.undef_method(method) if singleton_class.method_defined?(method)
 
         define_singleton_method(method) do
-          Taski::Context.set_root_task(self)
+          Taski.start_context(options: {}, root_task: self)
           validate_no_circular_dependencies!
           cached_wrapper.get_exported_value(method)
         end


### PR DESCRIPTION
## Summary

- Change Context from class methods to instance-based design
- Add user-defined options support via `Task.run(context: {...})`
- Options are immutable (frozen) after creation
- Access via `Taski.context[:key]`, `fetch(:key, default)`, `key?(:key)`
- Integrate `working_directory`, `started_at`, `root_task` into Context instance

## Usage

```ruby
class MyTask < Taski::Task
  def run
    env = Taski.context[:env]
    timeout = Taski.context.fetch(:timeout, 30)
    puts "Environment: #{env}, Timeout: #{timeout}"
  end
end

MyTask.run(context: { env: "production", debug: true })
```

## Known Issue

Context and cache relationship needs further consideration:
- Current: Second `run` with different context is ignored
- Under consideration: Should reset! and re-execute when context is provided
- See #48 for detailed discussion

## Test plan

- [x] Existing Context tests pass
- [x] New user-defined options tests pass
- [x] `rake test` - 87 tests, 256 assertions, 0 failures
- [x] `rake standard` - lint passed
- [x] `examples/context_demo.rb` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)