### PR TITLE
docs: add TaskAbortException documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,22 @@ RandomTask.new.run  # => 123 (new instance)
 RandomTask.reset!
 ```
 
+### Aborting Execution
+
+Stop all pending tasks when a critical error occurs:
+
+```ruby
+class CriticalTask < Taski::Task
+  def run
+    if fatal_error?
+      raise Taski::TaskAbortException, "Cannot continue"
+    end
+  end
+end
+```
+
+When `TaskAbortException` is raised, no new tasks will start. Already running tasks will complete, then execution stops.
+
 ### Progress Display
 
 Tree-based progress visualization is enabled by default:


### PR DESCRIPTION
## Summary

- Add documentation for `Taski::TaskAbortException` to the README
- Document how to stop all pending tasks when a critical error occurs
- Added in the Advanced Usage section after "Re-execution" and before "Progress Display"

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for task abort behavior, including how to halt execution when fatal errors occur
  * Provided Ruby code examples demonstrating the abort mechanism and execution flow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->