### PR TITLE
fix: add mutex protection to impl_call_order accessor

### DIFF
--- a/test/fixtures/parallel_tasks.rb
+++ b/test/fixtures/parallel_tasks.rb
@@ -587,7 +587,13 @@ module LazyDependencyTest
   @mutex = Mutex.new
 
   class << self
-    attr_accessor :impl_call_order
+    def impl_call_order
+      @mutex.synchronize { @impl_call_order }
+    end
+
+    def impl_call_order=(value)
+      @mutex.synchronize { @impl_call_order = value }
+    end
 
     def record(task_name)
       @mutex.synchronize do


### PR DESCRIPTION
## Summary
- Replace `attr_accessor :impl_call_order` with explicit getter/setter methods
- Add mutex synchronization for thread safety consistency with other methods in the module

## Details
The `LazyDependencyTest` module uses `@mutex.synchronize` for all operations (`record`, `executed_tasks`, `executed_before_impl?`, `reset`) except for `impl_call_order` accessor. This change adds mutex protection for consistency.

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test fixtures with improved synchronization handling for concurrent execution scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->