### PR TITLE
refactor: centralize tree building logic in TreeProgressDisplay

### DIFF
--- a/lib/taski/execution/tree_progress_display.rb
+++ b/lib/taski/execution/tree_progress_display.rb
@@ -45,31 +45,74 @@ module Taski
         child_name.start_with?("#{parent_name}::")
       end
 
+      # Build a tree structure from a root task class.
+      # This is the shared tree building logic used by both static and progress display.
+      #
+      # @param task_class [Class] The task class to build tree for
+      # @param ancestors [Set] Set of ancestor task classes for circular detection
+      # @return [Hash, nil] Tree node hash or nil if circular
+      #
+      # Tree node structure:
+      #   {
+      #     task_class: Class,       # The task class
+      #     is_section: Boolean,     # Whether this is a Section
+      #     is_circular: Boolean,    # Whether this is a circular reference
+      #     is_impl_candidate: Boolean, # Whether this is an impl candidate
+      #     children: Array<Hash>    # Child nodes
+      #   }
+      def self.build_tree_node(task_class, ancestors = Set.new)
+        is_circular = ancestors.include?(task_class)
+
+        node = {
+          task_class: task_class,
+          is_section: section_class?(task_class),
+          is_circular: is_circular,
+          is_impl_candidate: false,
+          children: []
+        }
+
+        # Don't traverse children for circular references
+        return node if is_circular
+
+        new_ancestors = ancestors + [task_class]
+        dependencies = StaticAnalysis::Analyzer.analyze(task_class).to_a
+        is_section = section_class?(task_class)
+
+        dependencies.each do |dep|
+          child_node = build_tree_node(dep, new_ancestors)
+          child_node[:is_impl_candidate] = is_section && nested_class?(dep, task_class)
+          node[:children] << child_node
+        end
+
+        node
+      end
+
       # Render a static tree structure for a task class (used by Task.tree)
       # @param root_task_class [Class] The root task class
       # @return [String] The rendered tree string
       def self.render_static_tree(root_task_class)
-        renderer = StaticTreeRenderer.new
-        renderer.render(root_task_class)
+        tree = build_tree_node(root_task_class)
+        formatter = StaticTreeFormatter.new
+        formatter.format(tree)
       end
 
-      # Internal renderer for static tree display (no progress tracking)
-      class StaticTreeRenderer
-        def render(root_task_class)
+      # Formatter for static tree display (no progress tracking, uses task numbers)
+      class StaticTreeFormatter
+        def format(tree)
           @task_index_map = {}
-          build_tree(root_task_class, "", false, Set.new)
+          format_node(tree, "", false)
         end
 
         private
 
-        def build_tree(task_class, prefix, is_impl, ancestors)
+        def format_node(node, prefix, is_impl)
+          task_class = node[:task_class]
           type_label = colored_type_label(task_class)
           impl_prefix = is_impl ? "#{COLORS[:impl]}[impl]#{COLORS[:reset]} " : ""
           task_number = get_task_number(task_class)
           name = "#{COLORS[:name]}#{task_class.name}#{COLORS[:reset]}"
 
-          # Detect circular reference
-          if ancestors.include?(task_class)
+          if node[:is_circular]
             circular_marker = "#{COLORS[:impl]}(circular)#{COLORS[:reset]}"
             return "#{impl_prefix}#{task_number} #{name} #{type_label} #{circular_marker}\n"
           end
@@ -79,26 +122,21 @@ module Taski
           # Register task number if not already registered
           @task_index_map[task_class] = @task_index_map.size + 1 unless @task_index_map.key?(task_class)
 
-          new_ancestors = ancestors + [task_class]
-          dependencies = StaticAnalysis::Analyzer.analyze(task_class).to_a
-          is_section = TreeProgressDisplay.section_class?(task_class)
-
-          dependencies.each_with_index do |dep, index|
-            is_last = (index == dependencies.size - 1)
-            is_impl_candidate = is_section && TreeProgressDisplay.nested_class?(dep, task_class)
-            result += render_dependency_branch(dep, prefix, is_last, is_impl_candidate, new_ancestors)
+          node[:children].each_with_index do |child, index|
+            is_last = (index == node[:children].size - 1)
+            result += format_child_branch(child, prefix, is_last)
           end
 
           result
         end
 
-        def render_dependency_branch(dep, prefix, is_last, is_impl, ancestors)
+        def format_child_branch(child, prefix, is_last)
           connector = is_last ? "└── " : "├── "
           extension = is_last ? "    " : "│   "
-          dep_tree = build_tree(dep, "#{prefix}#{extension}", is_impl, ancestors)
+          child_tree = format_node(child, "#{prefix}#{extension}", child[:is_impl_candidate])
 
           result = "#{prefix}#{COLORS[:tree]}#{connector}#{COLORS[:reset]}"
-          lines = dep_tree.lines
+          lines = child_tree.lines
           result += lines.first
           lines.drop(1).each { |line| result += line }
           result
@@ -269,36 +307,8 @@ module Taski
       def build_tree_structure
         return unless @root_task_class
 
-        @tree_structure = build_tree_node(@root_task_class, Set.new)
+        @tree_structure = self.class.build_tree_node(@root_task_class)
         register_tasks_from_tree(@tree_structure)
-      end
-
-      # Build a single tree node
-      def build_tree_node(task_class, ancestors)
-        return nil if ancestors.include?(task_class)
-
-        node = {
-          task_class: task_class,
-          is_section: section_class?(task_class),
-          children: [],
-          is_impl_candidate: false
-        }
-
-        new_ancestors = ancestors + [task_class]
-        dependencies = StaticAnalysis::Analyzer.analyze(task_class).to_a
-        is_section = section_class?(task_class)
-
-        dependencies.each do |dep|
-          child_node = build_tree_node(dep, new_ancestors)
-          if child_node
-            # Only mark as impl candidate if parent is Section AND
-            # the dependency is a nested class of that Section
-            child_node[:is_impl_candidate] = is_section && nested_class?(dep, task_class)
-            node[:children] << child_node
-          end
-        end
-
-        node
       end
 
       # Register all tasks from tree structure


### PR DESCRIPTION
## Summary

- Extract shared tree building logic into `TreeProgressDisplay.build_tree_node` class method
- Rename `StaticTreeRenderer` to `StaticTreeFormatter` (formatting only, no tree building)
- Both static and progress display now use the same tree building logic

## Changes

### Tree Building (shared)

`TreeProgressDisplay.build_tree_node(task_class, ancestors)` returns:

```ruby
{
  task_class: Class,
  is_section: Boolean,
  is_circular: Boolean,
  is_impl_candidate: Boolean,
  children: Array<Hash>
}
```

### Formatting (separate)

| Class | Purpose |
|-------|---------|
| `StaticTreeFormatter` | Formats tree with task numbers `[1]`, `[2]` |
| `TreeProgressDisplay` | Formats tree with status icons `⏸`, `✓`, `✗` |

## Test plan

- [x] All existing tests pass (194 tests, 496 assertions)
- [x] Lint (Standard Ruby) passes
- [x] Static tree output verified
- [x] Circular reference markers display correctly
- [x] Progress display works correctly

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved task tree rendering and visualization with enhanced handling of complex task dependencies and circular references.
  * Unified rendering behavior between static and dynamic task progress displays for greater consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->