### PR TITLE
fix: add thread-safety to Registry#get_or_create

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    taski (0.4.2)
+    taski (0.6.0)
       prism (~> 1.4)
       tsort
 

--- a/lib/taski/execution/registry.rb
+++ b/lib/taski/execution/registry.rb
@@ -16,7 +16,9 @@ module Taski
       # @yield Block to create the task instance if it doesn't exist
       # @return [Object] The task instance
       def get_or_create(task_class)
-        @tasks[task_class] ||= yield
+        @monitor.synchronize do
+          @tasks[task_class] ||= yield
+        end
       end
 
       # @param task_class [Class] The task class


### PR DESCRIPTION
## Summary

- Add `@monitor.synchronize` to `Registry#get_or_create` method to prevent race conditions

## Problem

`get_or_create` lacked synchronization, which could cause:
- Multiple threads evaluating `@tasks[task_class]` as `nil` simultaneously
- Duplicate task instances being created
- One instance overwriting another, leading to inconsistent state

## Solution

Wrap the method body with `@monitor.synchronize` block, consistent with other thread-safe methods in the class.

```ruby
def get_or_create(task_class)
  @monitor.synchronize do
    @tasks[task_class] ||= yield
  end
end
```

## Test plan

- [x] All existing tests pass (217 runs, 596 assertions, 0 failures)
- [x] Code style check passes

Fixes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved thread-safety mechanisms for concurrent task instance creation to enhance system reliability under high-load scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->