### PR TITLE
refactor: rename context to args for clarity

### DIFF
--- a/lib/taski.rb
+++ b/lib/taski.rb
@@ -11,7 +11,7 @@ require_relative "taski/execution/scheduler"
 require_relative "taski/execution/worker_pool"
 require_relative "taski/execution/executor"
 require_relative "taski/execution/tree_progress_display"
-require_relative "taski/context"
+require_relative "taski/args"
 require_relative "taski/task"
 require_relative "taski/section"
 
@@ -31,27 +31,27 @@ module Taski
     end
   end
 
-  @context_monitor = Monitor.new
+  @args_monitor = Monitor.new
 
-  # Get the current execution context
-  # @return [Context, nil] The current context or nil if no task is running
-  def self.context
-    @context_monitor.synchronize { @context }
+  # Get the current runtime arguments
+  # @return [Args, nil] The current args or nil if no task is running
+  def self.args
+    @args_monitor.synchronize { @args }
   end
 
-  # Start a new execution context (internal use only)
+  # Start new runtime arguments (internal use only)
   # @api private
-  def self.start_context(options:, root_task:)
-    @context_monitor.synchronize do
-      return if @context
-      @context = Context.new(options: options, root_task: root_task)
+  def self.start_args(options:, root_task:)
+    @args_monitor.synchronize do
+      return if @args
+      @args = Args.new(options: options, root_task: root_task)
     end
   end
 
-  # Reset the execution context (internal use only)
+  # Reset the runtime arguments (internal use only)
   # @api private
-  def self.reset_context!
-    @context_monitor.synchronize { @context = nil }
+  def self.reset_args!
+    @args_monitor.synchronize { @args = nil }
   end
 
   def self.global_registry
@@ -79,10 +79,10 @@ module Taski
     @progress_display = nil
   end
 
-  # Get the worker count from the current context (set via Task.run(workers: n))
+  # Get the worker count from the current args (set via Task.run(workers: n))
   # @return [Integer, nil] The worker count or nil to use WorkerPool default
   # @api private
-  def self.context_worker_count
-    context&.fetch(:_workers, nil)
+  def self.args_worker_count
+    args&.fetch(:_workers, nil)
   end
 end

--- a/lib/taski/args.rb
+++ b/lib/taski/args.rb
@@ -3,10 +3,10 @@
 require "monitor"
 
 module Taski
-  # Runtime context accessible from any task.
+  # Runtime arguments accessible from any task.
   # Holds user-defined options and execution metadata.
-  # Context is immutable after creation - options cannot be modified during task execution.
-  class Context
+  # Args is immutable after creation - options cannot be modified during task execution.
+  class Args
     attr_reader :started_at, :working_directory, :root_task
 
     # @param options [Hash] User-defined options (immutable after creation)

--- a/lib/taski/execution/executor.rb
+++ b/lib/taski/execution/executor.rb
@@ -70,7 +70,7 @@ module Taski
       # Initialize an Executor and its internal coordination components.
       # @param [Object] registry - Task registry used to look up task definitions and state.
       # @param [Integer, nil] worker_count - Optional number of worker threads to use; when `nil`,
-      #   uses Taski.context_worker_count which retrieves the worker count from the execution context.
+      #   uses Taski.args_worker_count which retrieves the worker count from the runtime args.
       # @param [Taski::Execution::ExecutionContext, nil] execution_context - Optional execution context for observers and output capture; when `nil` a default context (with progress observer and execution trigger) is created.
       def initialize(registry:, worker_count: nil, execution_context: nil)
         @registry = registry
@@ -82,9 +82,9 @@ module Taski
         # Scheduler for dependency management
         @scheduler = Scheduler.new
 
-        # Determine effective worker count: explicit param > context > default
+        # Determine effective worker count: explicit param > args > default
         # Store as instance variable for consistent use in both run and clean phases
-        @effective_worker_count = worker_count || Taski.context_worker_count
+        @effective_worker_count = worker_count || Taski.args_worker_count
 
         # WorkerPool for thread management
         @worker_pool = WorkerPool.new(

--- a/lib/taski/task.rb
+++ b/lib/taski/task.rb
@@ -73,15 +73,15 @@ module Taski
 
       ##
       # Executes the task and all its dependencies.
-      # @param context [Hash] Context options passed to tasks.
+      # @param args [Hash] User-defined arguments accessible via Taski.args.
       # @param workers [Integer, nil] Number of worker threads for parallel execution.
       #   Must be a positive integer or nil.
       #   Use workers: 1 for sequential execution (useful for debugging).
       # @raise [ArgumentError] If workers is not a positive integer or nil.
       # @return [Object] The result of task execution.
-      def run(context: {}, workers: nil)
+      def run(args: {}, workers: nil)
         validate_workers!(workers)
-        Taski.start_context(options: context.merge(_workers: workers), root_task: self)
+        Taski.start_args(options: args.merge(_workers: workers), root_task: self)
         validate_no_circular_dependencies!
         cached_wrapper.run
       end
@@ -89,13 +89,13 @@ module Taski
       ##
       # Executes the clean phase for the task and all its dependencies.
       # Clean is executed in reverse dependency order.
-      # @param context [Hash] Context options passed to tasks.
+      # @param args [Hash] User-defined arguments accessible via Taski.args.
       # @param workers [Integer, nil] Number of worker threads for parallel execution.
       #   Must be a positive integer or nil.
       # @raise [ArgumentError] If workers is not a positive integer or nil.
-      def clean(context: {}, workers: nil)
+      def clean(args: {}, workers: nil)
         validate_workers!(workers)
-        Taski.start_context(options: context.merge(_workers: workers), root_task: self)
+        Taski.start_args(options: args.merge(_workers: workers), root_task: self)
         validate_no_circular_dependencies!
         cached_wrapper.clean
       end
@@ -104,14 +104,14 @@ module Taski
       # Execute run followed by clean in a single operation.
       # If run fails, clean is still executed for resource release.
       #
-      # @param context [Hash] Context options passed to tasks.
+      # @param args [Hash] User-defined arguments accessible via Taski.args.
       # @param workers [Integer, nil] Number of worker threads for parallel execution.
       #   Must be a positive integer or nil.
       # @raise [ArgumentError] If workers is not a positive integer or nil.
       # @return [Object] The result of task execution
-      def run_and_clean(context: {}, workers: nil)
+      def run_and_clean(args: {}, workers: nil)
         validate_workers!(workers)
-        Taski.start_context(options: context.merge(_workers: workers), root_task: self)
+        Taski.start_args(options: args.merge(_workers: workers), root_task: self)
         validate_no_circular_dependencies!
         cached_wrapper.run_and_clean
       end
@@ -124,12 +124,12 @@ module Taski
       end
 
       ##
-      # Resets the task state, registry, context, and progress display.
+      # Resets the task state, registry, args, and progress display.
       # Useful for testing or re-running tasks from scratch.
       def reset!
         registry.reset!
         Taski.reset_global_registry!
-        Taski.reset_context!
+        Taski.reset_args!
         Taski.reset_progress_display!
         @circular_dependency_checked = false
       end
@@ -180,7 +180,7 @@ module Taski
         singleton_class.undef_method(method) if singleton_class.method_defined?(method)
 
         define_singleton_method(method) do
-          Taski.start_context(options: {}, root_task: self)
+          Taski.start_args(options: {}, root_task: self)
           validate_no_circular_dependencies!
           cached_wrapper.get_exported_value(method)
         end

--- a/test/fixtures/parallel_tasks.rb
+++ b/test/fixtures/parallel_tasks.rb
@@ -396,8 +396,8 @@ module ImplDependsOnTaskTest
 
     def run
       ImplDependsOnTaskTest.record(:condition_task)
-      # Use context to control condition for testing
-      @use_fast_mode = Taski.context[:fast_mode] || false
+      # Use args to control condition for testing
+      @use_fast_mode = Taski.args[:fast_mode] || false
     end
   end
 
@@ -673,7 +673,7 @@ module LazyDependencyTest
       LazyDependencyTest.impl_call_order = Time.now
       # Conditional selection - both OptionA and OptionB are referenced in impl
       # Only the selected option's dependencies should be executed
-      if Taski.context[:use_option_a]
+      if Taski.args[:use_option_a]
         OptionA
       else
         OptionB

--- a/test/test_section.rb
+++ b/test/test_section.rb
@@ -92,8 +92,8 @@ class TestSection < Minitest::Test
   def test_section_lazy_dependency_resolution
     LazyDependencyTest.reset
 
-    # Run with context that selects OptionB
-    LazyDependencyTest::MySection.run(context: {use_option_a: false})
+    # Run with args that selects OptionB
+    LazyDependencyTest::MySection.run(args: {use_option_a: false})
 
     executed = LazyDependencyTest.executed_tasks
 
@@ -119,7 +119,7 @@ class TestSection < Minitest::Test
     ImplDependsOnTaskTest.reset
 
     # Run with fast_mode = true
-    ImplDependsOnTaskTest::FinalTask.run(context: {fast_mode: true})
+    ImplDependsOnTaskTest::FinalTask.run(args: {fast_mode: true})
 
     executed = ImplDependsOnTaskTest.executed_tasks
 
@@ -149,7 +149,7 @@ class TestSection < Minitest::Test
     ImplDependsOnTaskTest.reset
 
     # Run with fast_mode = false (default)
-    ImplDependsOnTaskTest::FinalTask.run(context: {fast_mode: false})
+    ImplDependsOnTaskTest::FinalTask.run(args: {fast_mode: false})
 
     executed = ImplDependsOnTaskTest.executed_tasks
 
@@ -181,7 +181,7 @@ class TestSection < Minitest::Test
   def test_section_impl_blocks_on_dependency
     ImplDependsOnTaskTest.reset
 
-    ImplDependsOnTaskTest::ConditionalSection.run(context: {fast_mode: true})
+    ImplDependsOnTaskTest::ConditionalSection.run(args: {fast_mode: true})
 
     executed = ImplDependsOnTaskTest.executed_tasks
 

--- a/test/test_worker_count_configuration.rb
+++ b/test/test_worker_count_configuration.rb
@@ -5,13 +5,13 @@ require_relative "test_helper"
 class TestWorkerCountConfiguration < Minitest::Test
   def setup
     Taski.reset_global_registry!
-    Taski.reset_context!
+    Taski.reset_args!
     Taski.reset_progress_display!
   end
 
   def teardown
     Taski.reset_global_registry!
-    Taski.reset_context!
+    Taski.reset_args!
     Taski.reset_progress_display!
   end
 
@@ -89,21 +89,21 @@ class TestWorkerCountConfiguration < Minitest::Test
   end
 
   # ========================================
-  # Context worker count API
+  # Args worker count API
   # ========================================
 
-  def test_context_worker_count_returns_nil_without_context
-    assert_nil Taski.context_worker_count
+  def test_args_worker_count_returns_nil_without_args
+    assert_nil Taski.args_worker_count
   end
 
-  def test_context_worker_count_returns_nil_when_not_set
-    Taski.start_context(options: {}, root_task: nil)
-    assert_nil Taski.context_worker_count
+  def test_args_worker_count_returns_nil_when_not_set
+    Taski.start_args(options: {}, root_task: nil)
+    assert_nil Taski.args_worker_count
   end
 
-  def test_context_worker_count_returns_value_when_set
-    Taski.start_context(options: {_workers: 4}, root_task: nil)
-    assert_equal 4, Taski.context_worker_count
+  def test_args_worker_count_returns_value_when_set
+    Taski.start_args(options: {_workers: 4}, root_task: nil)
+    assert_equal 4, Taski.args_worker_count
   end
 
   # ========================================
@@ -141,12 +141,12 @@ class TestWorkerCountConfiguration < Minitest::Test
   end
 
   # ========================================
-  # Combined context and workers test
+  # Combined args and workers test
   # ========================================
 
-  def test_workers_parameter_with_context_options
+  def test_workers_parameter_with_args_options
     SimpleTask.reset!
-    SimpleTask.run(context: {custom_key: "value"}, workers: 4)
+    SimpleTask.run(args: {custom_key: "value"}, workers: 4)
     assert_equal "done", SimpleTask.result
   end
 end


### PR DESCRIPTION
## Summary
- Rename `Context` class to `Args` for better clarity
- Change `Taski.context` to `Taski.args`
- Change `context:` parameter to `args:` in `Task.run/clean/run_and_clean`
- Update internal method names (`context_worker_count` → `args_worker_count`)

## Motivation
The term "context" was ambiguous and could be confused with execution context. "Args" more clearly communicates that these are user-provided arguments passed to task execution.

## Changes
- `lib/taski/context.rb` → `lib/taski/args.rb`
- `Taski.context` → `Taski.args`
- `Taski.start_context` → `Taski.start_args`
- `Taski.reset_context!` → `Taski.reset_args!`
- `Taski.context_worker_count` → `Taski.args_worker_count`
- `Task.run(context: {...})` → `Task.run(args: {...})`
- Updated all test files accordingly

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed runtime API from context to arguments: `Taski.context` → `Taski.args`
  * Updated task method signatures: `run(context: {})` → `run(args: {})`; same for `clean()` and `run_and_clean()`
  * Renamed lifecycle methods: `start_context()` → `start_args()`, `reset_context!()` → `reset_args!()`, `context_worker_count` → `args_worker_count`

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->