### PR TITLE
feat: add background polling to TaskOutputRouter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,13 @@ Thumbs.db
 # Development notes (create as needed)
 CLAUDE.md
 .serena
+.specify
+specs
 
 private_docs
 
 # RBS
 .gem_rbs_collection/
+
+*.html
+*.mermaid

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    taski (0.6.0)
+    taski (0.7.0)
       prism (~> 1.4)
       tsort
 
@@ -145,7 +145,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
-    unicode-emoji (4.1.0)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
 
 PLATFORMS

--- a/lib/taski/execution/execution_context.rb
+++ b/lib/taski/execution/execution_context.rb
@@ -98,6 +98,7 @@ module Taski
         @monitor.synchronize do
           @original_stdout = output_io
           @output_capture = TaskOutputRouter.new(@original_stdout)
+          @output_capture.start_polling
           $stdout = @output_capture
         end
 
@@ -106,13 +107,16 @@ module Taski
 
       # Tear down output capture and restore original $stdout.
       def teardown_output_capture
+        capture = nil
         @monitor.synchronize do
           return unless @original_stdout
 
+          capture = @output_capture
           $stdout = @original_stdout
           @output_capture = nil
           @original_stdout = nil
         end
+        capture&.stop_polling
       end
 
       # Get the current output capture instance.


### PR DESCRIPTION
- Add background polling thread to ensure pipes are drained even when display doesn't poll
- Improve IOError handling for pipes closed by other threads
- Add aggregate error tests