### PR TITLE
feat: Add test helper for mocking task dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,36 @@ puts WebServer.tree
 #     └── Cache (Task)
 ```
 
+## Testing
+
+### Test Helper for Mocking Dependencies
+
+Taski provides a test helper to mock task dependencies in your unit tests:
+
+```ruby
+require 'taski/test_helper/minitest'
+
+class BuildReportTest < Minitest::Test
+  include Taski::TestHelper::Minitest
+
+  def test_builds_report
+    # Mock direct dependencies - their run methods won't execute
+    mock_task(FetchData, users: [1, 2, 3])
+
+    # Task under test uses mocked values
+    assert_equal 3, BuildReport.user_count
+  end
+end
+```
+
+**Key features:**
+- Mock only direct dependencies; indirect dependencies are automatically isolated
+- Verify which dependencies were accessed with `assert_task_accessed` / `refute_task_accessed`
+- Automatic cleanup after each test
+- Supports both Minitest and RSpec
+
+For RSpec, use `include Taski::TestHelper::RSpec` instead.
+
 ## Development
 
 ```bash

--- a/lib/taski/test_helper.rb
+++ b/lib/taski/test_helper.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require_relative "test_helper/errors"
+require_relative "test_helper/mock_wrapper"
+require_relative "test_helper/mock_registry"
+
+module Taski
+  # Test helper module for mocking Taski task dependencies in unit tests.
+  # Include this module in your test class to access mocking functionality.
+  #
+  # @example Minitest usage
+  #   class BuildReportTest < Minitest::Test
+  #     include Taski::TestHelper
+  #
+  #     def test_builds_report
+  #       mock_task(FetchData, users: [1, 2, 3])
+  #       assert_equal 3, BuildReport.user_count
+  #     end
+  #   end
+  module TestHelper
+    # Module prepended to Task's singleton class to intercept define_class_accessor.
+    # @api private
+    module TaskExtension
+      def define_class_accessor(method)
+        singleton_class.undef_method(method) if singleton_class.method_defined?(method)
+
+        define_singleton_method(method) do
+          # Check for mock first
+          mock = MockRegistry.mock_for(self)
+          return mock.get_exported_value(method) if mock
+
+          # No mock - call original implementation via registry lookup
+          registry = Taski.current_registry
+          if registry
+            wrapper = registry.get_or_create(self) do
+              task_instance = allocate
+              task_instance.__send__(:initialize)
+              Execution::TaskWrapper.new(
+                task_instance,
+                registry: registry,
+                execution_context: Execution::ExecutionContext.current
+              )
+            end
+            wrapper.get_exported_value(method)
+          else
+            Taski.with_args(options: {}, root_task: self) do
+              validate_no_circular_dependencies!
+              fresh_wrapper.get_exported_value(method)
+            end
+          end
+        end
+      end
+    end
+
+    # Module prepended to Scheduler to skip dependencies of mocked tasks.
+    # @api private
+    module SchedulerExtension
+      def build_dependency_graph(root_task_class)
+        queue = [root_task_class]
+
+        while (task_class = queue.shift)
+          next if @task_states.key?(task_class)
+
+          # Mocked tasks have no dependencies (isolates indirect dependencies)
+          mock = MockRegistry.mock_for(task_class)
+          deps = mock ? Set.new : task_class.cached_dependencies
+          @dependencies[task_class] = deps.dup
+          @task_states[task_class] = Taski::Execution::Scheduler::STATE_PENDING
+
+          deps.each { |dep| queue << dep }
+        end
+      end
+    end
+
+    # Module prepended to Executor to skip execution of mocked tasks.
+    # @api private
+    module ExecutorExtension
+      def execute_task(task_class, wrapper)
+        return if @registry.abort_requested?
+
+        # Skip execution if task is mocked
+        if MockRegistry.mock_for(task_class)
+          wrapper.mark_completed(nil)
+          @completion_queue.push({task_class: task_class, wrapper: wrapper})
+          return
+        end
+
+        super
+      end
+    end
+
+    class << self
+      # Checks if any mocks are currently registered.
+      # @return [Boolean] true if mocks exist
+      def mocks_active?
+        MockRegistry.mocks_active?
+      end
+
+      # Retrieves the mock wrapper for a task class.
+      # @param task_class [Class] The task class to look up
+      # @return [MockWrapper, nil] The mock wrapper or nil if not mocked
+      def mock_for(task_class)
+        MockRegistry.mock_for(task_class)
+      end
+
+      # Clears all registered mocks.
+      # Called automatically by test framework integrations.
+      def reset_mocks!
+        MockRegistry.reset!
+      end
+    end
+
+    # Registers a mock for a task class with specified return values.
+    # @param task_class [Class] A Taski::Task or Taski::Section subclass
+    # @param values [Hash{Symbol => Object}] Method names mapped to return values
+    # @return [MockWrapper] The created mock wrapper
+    # @raise [InvalidTaskError] If task_class is not a Taski::Task/Section subclass
+    # @raise [InvalidMethodError] If any method name is not an exported method
+    #
+    # @example
+    #   mock_task(FetchData, result: { users: [1, 2, 3] })
+    #   mock_task(Config, timeout: 30, retries: 3)
+    def mock_task(task_class, **values)
+      validate_task_class!(task_class)
+      validate_exported_methods!(task_class, values.keys)
+
+      mock_wrapper = MockWrapper.new(task_class, values)
+      MockRegistry.register(task_class, mock_wrapper)
+      mock_wrapper
+    end
+
+    # Asserts that a mocked task's method was accessed during the test.
+    # @param task_class [Class] The mocked task class
+    # @param method_name [Symbol] The exported method name
+    # @return [true] If assertion passes
+    # @raise [ArgumentError] If task_class was not mocked
+    # @raise [Minitest::Assertion, RSpec::Expectations::ExpectationNotMetError]
+    #   If method was not accessed
+    def assert_task_accessed(task_class, method_name)
+      mock = fetch_mock!(task_class)
+
+      unless mock.accessed?(method_name)
+        raise assertion_error("Expected #{task_class}.#{method_name} to be accessed, but it was not")
+      end
+
+      true
+    end
+
+    # Asserts that a mocked task's method was NOT accessed during the test.
+    # @param task_class [Class] The mocked task class
+    # @param method_name [Symbol] The exported method name
+    # @return [true] If assertion passes
+    # @raise [ArgumentError] If task_class was not mocked
+    # @raise [Minitest::Assertion, RSpec::Expectations::ExpectationNotMetError]
+    #   If method was accessed
+    def refute_task_accessed(task_class, method_name)
+      mock = fetch_mock!(task_class)
+
+      if mock.accessed?(method_name)
+        count = mock.access_count(method_name)
+        raise assertion_error(
+          "Expected #{task_class}.#{method_name} not to be accessed, but it was accessed #{count} time(s)"
+        )
+      end
+
+      true
+    end
+
+    private
+
+    def fetch_mock!(task_class)
+      mock = MockRegistry.mock_for(task_class)
+      return mock if mock
+
+      raise ArgumentError, "Task #{task_class} was not mocked. Call mock_task first."
+    end
+
+    def validate_task_class!(task_class)
+      valid = task_class.is_a?(Class) &&
+        (task_class < Taski::Task || task_class == Taski::Task)
+      return if valid
+
+      raise InvalidTaskError,
+        "Cannot mock #{task_class}: not a Taski::Task or Taski::Section subclass"
+    end
+
+    def validate_exported_methods!(task_class, method_names)
+      exported = task_class.exported_methods
+      method_names.each do |method_name|
+        unless exported.include?(method_name)
+          raise InvalidMethodError,
+            "Cannot mock :#{method_name} on #{task_class}: not an exported method. Exported: #{exported.inspect}"
+        end
+      end
+    end
+
+    def assertion_error(message)
+      # Use the appropriate assertion error class based on the test framework
+      # Use fully qualified names to avoid namespace conflicts
+      if defined?(::Minitest::Assertion)
+        ::Minitest::Assertion.new(message)
+      elsif defined?(::RSpec::Expectations::ExpectationNotMetError)
+        ::RSpec::Expectations::ExpectationNotMetError.new(message)
+      else
+        RuntimeError.new(message)
+      end
+    end
+  end
+end
+
+# Prepend extensions when test helper is loaded
+Taski::Task.singleton_class.prepend(Taski::TestHelper::TaskExtension)
+Taski::Execution::Scheduler.prepend(Taski::TestHelper::SchedulerExtension)
+Taski::Execution::Executor.prepend(Taski::TestHelper::ExecutorExtension)

--- a/lib/taski/test_helper/errors.rb
+++ b/lib/taski/test_helper/errors.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Taski
+  module TestHelper
+    # Raised when attempting to mock a class that is not a Taski::Task or Taski::Section subclass.
+    class InvalidTaskError < ArgumentError
+    end
+
+    # Raised when attempting to mock a method that is not an exported method of the task.
+    class InvalidMethodError < ArgumentError
+    end
+  end
+end

--- a/lib/taski/test_helper/minitest.rb
+++ b/lib/taski/test_helper/minitest.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Taski
+  module TestHelper
+    # Minitest integration module.
+    # Include this in your test class for automatic mock cleanup.
+    #
+    # @example
+    #   class MyTaskTest < Minitest::Test
+    #     include Taski::TestHelper::Minitest
+    #
+    #     def test_something
+    #       mock_task(FetchData, result: "mocked")
+    #       # ... test code ...
+    #     end
+    #     # Mocks are automatically cleaned up after each test
+    #   end
+    module Minitest
+      def self.included(base)
+        base.include(Taski::TestHelper)
+      end
+
+      # Reset mocks before each test to ensure clean state.
+      def setup
+        super
+        Taski::TestHelper.reset_mocks!
+      end
+
+      # Reset mocks after each test to prevent pollution.
+      def teardown
+        Taski::TestHelper.reset_mocks!
+        super
+      end
+    end
+  end
+end

--- a/lib/taski/test_helper/mock_registry.rb
+++ b/lib/taski/test_helper/mock_registry.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Taski
+  module TestHelper
+    # Global registry that stores mock definitions for tests.
+    # Uses a Mutex for thread-safety when accessed from worker threads.
+    # Mocks should be reset in test setup/teardown to ensure test isolation.
+    module MockRegistry
+      @mutex = Mutex.new
+      @mocks = {}
+
+      class << self
+        # Registers a mock for a task class.
+        # If a mock already exists for this class, it is replaced.
+        # @param task_class [Class] The task class to mock
+        # @param mock_wrapper [MockWrapper] The mock wrapper instance
+        def register(task_class, mock_wrapper)
+          @mutex.synchronize do
+            @mocks[task_class] = mock_wrapper
+          end
+        end
+
+        # Retrieves the mock wrapper for a task class, if one exists.
+        # @param task_class [Class] The task class to look up
+        # @return [MockWrapper, nil] The mock wrapper or nil if not mocked
+        def mock_for(task_class)
+          @mutex.synchronize do
+            @mocks[task_class]
+          end
+        end
+
+        # Checks if any mocks are registered.
+        # Used for optimization to skip mock lookup in hot paths.
+        # @return [Boolean] true if mocks exist
+        def mocks_active?
+          @mutex.synchronize do
+            !@mocks.empty?
+          end
+        end
+
+        # Clears all registered mocks.
+        # Should be called in test setup/teardown.
+        def reset!
+          @mutex.synchronize do
+            @mocks = {}
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/taski/test_helper/mock_wrapper.rb
+++ b/lib/taski/test_helper/mock_wrapper.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Taski
+  module TestHelper
+    # Wraps a mocked task and returns pre-configured values without executing the task.
+    # Tracks which methods were accessed for verification in tests.
+    class MockWrapper
+      attr_reader :task_class, :mock_values
+
+      # @param task_class [Class] The task class being mocked
+      # @param mock_values [Hash{Symbol => Object}] Method names mapped to their return values
+      def initialize(task_class, mock_values)
+        @task_class = task_class
+        @mock_values = mock_values
+        @access_counts = Hash.new(0)
+      end
+
+      # Returns the mocked value for a method and records the access.
+      # @param method_name [Symbol] The exported method name
+      # @return [Object] The pre-configured mock value
+      # @raise [KeyError] If method_name was not configured in the mock
+      def get_exported_value(method_name)
+        unless @mock_values.key?(method_name)
+          raise KeyError, "No mock value for method :#{method_name} on #{@task_class}"
+        end
+
+        @access_counts[method_name] += 1
+        @mock_values[method_name]
+      end
+
+      # Checks if a method was accessed at least once.
+      # @param method_name [Symbol] The method name to check
+      # @return [Boolean] true if accessed at least once
+      def accessed?(method_name)
+        @access_counts[method_name] > 0
+      end
+
+      # Returns the number of times a method was accessed.
+      # @param method_name [Symbol] The method name to check
+      # @return [Integer] Number of accesses (0 if never accessed)
+      def access_count(method_name)
+        @access_counts[method_name]
+      end
+    end
+  end
+end

--- a/lib/taski/test_helper/rspec.rb
+++ b/lib/taski/test_helper/rspec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Taski
+  module TestHelper
+    # RSpec integration module.
+    # Include this in your RSpec examples for automatic mock cleanup.
+    #
+    # @example In spec_helper.rb
+    #   require 'taski/test_helper/rspec'
+    #
+    #   RSpec.configure do |config|
+    #     config.include Taski::TestHelper::RSpec
+    #   end
+    #
+    # @example In individual specs
+    #   RSpec.describe MyTask do
+    #     include Taski::TestHelper::RSpec
+    #
+    #     it "processes data" do
+    #       mock_task(FetchData, result: "mocked")
+    #       # ... test code ...
+    #     end
+    #   end
+    module RSpec
+      def self.included(base)
+        base.include(Taski::TestHelper)
+
+        # Add before/after hooks when included in RSpec
+        if base.respond_to?(:before) && base.respond_to?(:after)
+          base.before(:each) { Taski::TestHelper.reset_mocks! }
+          base.after(:each) { Taski::TestHelper.reset_mocks! }
+        end
+      end
+    end
+  end
+end

--- a/test/test_test_helper.rb
+++ b/test/test_test_helper.rb
@@ -1,0 +1,525 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "taski/test_helper"
+require "taski/test_helper/minitest"
+
+# Fixture tasks for testing the test helper
+module TestHelperFixtures
+  # A simple task with no dependencies
+  class LeafTask < Taski::Task
+    exports :value
+
+    def run
+      @value = "leaf_result"
+    end
+  end
+
+  # A task that depends on LeafTask (direct dependency)
+  class MiddleTask < Taski::Task
+    exports :result
+
+    def run
+      @result = "middle_" + LeafTask.value
+    end
+  end
+
+  # A task that depends on MiddleTask (MiddleTask is direct, LeafTask is indirect)
+  class TopTask < Taski::Task
+    exports :output
+
+    def run
+      @output = "top_" + MiddleTask.result
+    end
+  end
+
+  # A task with multiple exports
+  class MultiExportTask < Taski::Task
+    exports :first, :second, :third
+
+    def run
+      @first = "first_value"
+      @second = "second_value"
+      @third = "third_value"
+    end
+  end
+
+  # A task that depends on multiple tasks
+  class MultiDependencyTask < Taski::Task
+    exports :combined
+
+    def run
+      @combined = LeafTask.value + "_" + MultiExportTask.first
+    end
+  end
+
+  # A Section for testing Section API mocking
+  class DataSourceSection < Taski::Section
+    interfaces :data
+  end
+
+  class FileDataSource < Taski::Task
+    exports :data
+
+    def run
+      @data = "file_data"
+    end
+  end
+
+  class SectionConsumer < Taski::Task
+    exports :processed
+
+    def run
+      @processed = "processed_" + DataSourceSection.data
+    end
+  end
+end
+
+class TestTestHelper < Minitest::Test
+  include Taski::TestHelper
+
+  def setup
+    Taski::TestHelper.reset_mocks!
+    Taski::Task.reset!
+  end
+
+  def teardown
+    Taski::TestHelper.reset_mocks!
+  end
+
+  # === T007: Test basic mock registration and retrieval ===
+  def test_mock_task_registers_mock
+    mock = mock_task(TestHelperFixtures::LeafTask, value: "mocked_value")
+
+    assert_instance_of Taski::TestHelper::MockWrapper, mock
+    assert_equal TestHelperFixtures::LeafTask, mock.task_class
+    assert_equal({value: "mocked_value"}, mock.mock_values)
+  end
+
+  def test_mock_for_returns_registered_mock
+    mock_task(TestHelperFixtures::LeafTask, value: "mocked")
+
+    retrieved = Taski::TestHelper.mock_for(TestHelperFixtures::LeafTask)
+    assert_instance_of Taski::TestHelper::MockWrapper, retrieved
+  end
+
+  def test_mock_for_returns_nil_for_unregistered_task
+    assert_nil Taski::TestHelper.mock_for(TestHelperFixtures::LeafTask)
+  end
+
+  def test_mocks_active_returns_true_when_mocks_registered
+    refute Taski::TestHelper.mocks_active?
+
+    mock_task(TestHelperFixtures::LeafTask, value: "mocked")
+
+    assert Taski::TestHelper.mocks_active?
+  end
+
+  # === T008: Test mocked task returns configured value ===
+  def test_mocked_task_returns_mock_value
+    mock_task(TestHelperFixtures::LeafTask, value: "mocked_leaf")
+
+    result = TestHelperFixtures::LeafTask.value
+
+    assert_equal "mocked_leaf", result
+  end
+
+  def test_mocked_task_with_multiple_exports
+    mock_task(TestHelperFixtures::MultiExportTask,
+      first: "mock_first",
+      second: "mock_second",
+      third: "mock_third")
+
+    assert_equal "mock_first", TestHelperFixtures::MultiExportTask.first
+    assert_equal "mock_second", TestHelperFixtures::MultiExportTask.second
+    assert_equal "mock_third", TestHelperFixtures::MultiExportTask.third
+  end
+
+  # === T009: Test mocked dependency task's run method is not executed ===
+  def test_mocked_task_run_not_executed
+    run_executed = false
+
+    # Create a task class dynamically to track execution
+    task_class = Class.new(Taski::Task) do
+      exports :output
+
+      define_method(:run) do
+        run_executed = true
+        @output = "real_output"
+      end
+    end
+
+    mock_task(task_class, output: "mocked_output")
+    result = task_class.output
+
+    assert_equal "mocked_output", result
+    refute run_executed, "run method should not have been executed"
+  end
+
+  # === T010: Test multiple direct dependencies can be mocked ===
+  def test_multiple_dependencies_mocked
+    mock_task(TestHelperFixtures::LeafTask, value: "mocked_leaf")
+    mock_task(TestHelperFixtures::MultiExportTask, first: "mocked_first")
+
+    result = TestHelperFixtures::MultiDependencyTask.combined
+
+    assert_equal "mocked_leaf_mocked_first", result
+  end
+
+  # === T011: Test indirect dependencies are automatically isolated ===
+  def test_indirect_dependencies_isolated
+    leaf_run_executed = false
+    original_run = TestHelperFixtures::LeafTask.instance_method(:run)
+
+    # Temporarily replace LeafTask#run to track if it's called
+    TestHelperFixtures::LeafTask.define_method(:run) do
+      leaf_run_executed = true
+      @value = "should_not_be_used"
+    end
+
+    begin
+      # Mock only MiddleTask (direct dependency of TopTask)
+      # LeafTask is indirect and should not run
+      mock_task(TestHelperFixtures::MiddleTask, result: "mocked_middle")
+
+      result = TestHelperFixtures::TopTask.output
+
+      assert_equal "top_mocked_middle", result
+      refute leaf_run_executed, "LeafTask (indirect dependency) should not have run"
+    ensure
+      TestHelperFixtures::LeafTask.define_method(:run, original_run)
+    end
+  end
+
+  # === T012: Test mock value is returned consistently on multiple accesses ===
+  def test_mock_value_consistent_on_multiple_accesses
+    mock_task(TestHelperFixtures::LeafTask, value: "consistent_value")
+
+    # Access multiple times
+    result1 = TestHelperFixtures::LeafTask.value
+    result2 = TestHelperFixtures::LeafTask.value
+    result3 = TestHelperFixtures::LeafTask.value
+
+    assert_equal "consistent_value", result1
+    assert_equal "consistent_value", result2
+    assert_equal "consistent_value", result3
+  end
+
+  # === T015: Test validation for task class (FR-012) ===
+  def test_mock_invalid_task_class_raises_error
+    error = assert_raises(Taski::TestHelper::InvalidTaskError) do
+      mock_task(String, foo: "bar")
+    end
+
+    assert_match(/not a Taski::Task/, error.message)
+    assert_match(/String/, error.message)
+  end
+
+  def test_mock_non_class_raises_error
+    error = assert_raises(Taski::TestHelper::InvalidTaskError) do
+      mock_task("not_a_class", foo: "bar")
+    end
+
+    assert_match(/not a Taski::Task/, error.message)
+  end
+
+  # === T016: Test validation for exported methods (FR-013) ===
+  def test_mock_invalid_method_raises_error
+    error = assert_raises(Taski::TestHelper::InvalidMethodError) do
+      mock_task(TestHelperFixtures::LeafTask, nonexistent: "value")
+    end
+
+    assert_match(/not an exported method/, error.message)
+    assert_match(/:nonexistent/, error.message)
+    assert_match(/LeafTask/, error.message)
+    assert_match(/\[:value\]/, error.message)
+  end
+
+  def test_mock_partial_invalid_methods_raises_error
+    error = assert_raises(Taski::TestHelper::InvalidMethodError) do
+      mock_task(TestHelperFixtures::MultiExportTask,
+        first: "valid",
+        invalid_method: "invalid")
+    end
+
+    assert_match(/:invalid_method/, error.message)
+  end
+
+  # === Additional tests for robustness ===
+  def test_reset_mocks_clears_all_mocks
+    mock_task(TestHelperFixtures::LeafTask, value: "mocked")
+    assert Taski::TestHelper.mocks_active?
+
+    Taski::TestHelper.reset_mocks!
+
+    refute Taski::TestHelper.mocks_active?
+    assert_nil Taski::TestHelper.mock_for(TestHelperFixtures::LeafTask)
+  end
+
+  def test_duplicate_mock_registration_overwrites
+    mock_task(TestHelperFixtures::LeafTask, value: "first")
+    mock_task(TestHelperFixtures::LeafTask, value: "second")
+
+    result = TestHelperFixtures::LeafTask.value
+
+    assert_equal "second", result
+  end
+
+  def test_mock_with_nil_value
+    mock_task(TestHelperFixtures::LeafTask, value: nil)
+
+    result = TestHelperFixtures::LeafTask.value
+
+    assert_nil result
+  end
+
+  def test_mock_with_complex_value
+    complex_value = {users: [1, 2, 3], metadata: {count: 3}}
+    mock_task(TestHelperFixtures::LeafTask, value: complex_value)
+
+    result = TestHelperFixtures::LeafTask.value
+
+    assert_equal complex_value, result
+    assert_equal [1, 2, 3], result[:users]
+  end
+
+  # === T017: Test access tracking records method calls ===
+  def test_access_tracking_records_method_calls
+    mock = mock_task(TestHelperFixtures::LeafTask, value: "test")
+
+    refute mock.accessed?(:value)
+    assert_equal 0, mock.access_count(:value)
+
+    TestHelperFixtures::LeafTask.value
+
+    assert mock.accessed?(:value)
+    assert_equal 1, mock.access_count(:value)
+
+    TestHelperFixtures::LeafTask.value
+    TestHelperFixtures::LeafTask.value
+
+    assert_equal 3, mock.access_count(:value)
+  end
+
+  # === T018: Test assert_task_accessed passes when method was accessed ===
+  def test_assert_task_accessed_passes_when_accessed
+    mock_task(TestHelperFixtures::LeafTask, value: "test")
+    TestHelperFixtures::LeafTask.value
+
+    # Should not raise
+    assert_task_accessed(TestHelperFixtures::LeafTask, :value)
+  end
+
+  # === T019: Test assert_task_accessed fails when method was not accessed ===
+  def test_assert_task_accessed_fails_when_not_accessed
+    mock_task(TestHelperFixtures::LeafTask, value: "test")
+    # Do NOT access the value
+
+    error = assert_raises(::Minitest::Assertion) do
+      assert_task_accessed(TestHelperFixtures::LeafTask, :value)
+    end
+
+    assert_match(/LeafTask/, error.message)
+    assert_match(/value/, error.message)
+    assert_match(/not/, error.message)
+  end
+
+  # === T020: Test refute_task_accessed passes when method was not accessed ===
+  def test_refute_task_accessed_passes_when_not_accessed
+    mock_task(TestHelperFixtures::LeafTask, value: "test")
+    # Do NOT access the value
+
+    # Should not raise
+    refute_task_accessed(TestHelperFixtures::LeafTask, :value)
+  end
+
+  def test_refute_task_accessed_fails_when_accessed
+    mock_task(TestHelperFixtures::LeafTask, value: "test")
+    TestHelperFixtures::LeafTask.value
+
+    error = assert_raises(::Minitest::Assertion) do
+      refute_task_accessed(TestHelperFixtures::LeafTask, :value)
+    end
+
+    assert_match(/LeafTask/, error.message)
+    assert_match(/value/, error.message)
+    assert_match(/1 time/, error.message)
+  end
+
+  def test_assert_task_accessed_raises_when_task_not_mocked
+    error = assert_raises(ArgumentError) do
+      assert_task_accessed(TestHelperFixtures::LeafTask, :value)
+    end
+
+    assert_match(/not mocked/, error.message)
+  end
+
+  def test_refute_task_accessed_raises_when_task_not_mocked
+    error = assert_raises(ArgumentError) do
+      refute_task_accessed(TestHelperFixtures::LeafTask, :value)
+    end
+
+    assert_match(/not mocked/, error.message)
+  end
+end
+
+# === T025-T027: Test Minitest integration ===
+class TestMinitestIntegration < Minitest::Test
+  include Taski::TestHelper::Minitest
+
+  # Test that mock_task is available via the module
+  def test_minitest_module_includes_helper_methods
+    assert respond_to?(:mock_task)
+    assert respond_to?(:assert_task_accessed)
+    assert respond_to?(:refute_task_accessed)
+  end
+
+  # Test automatic cleanup - this test should start with no mocks
+  def test_automatic_cleanup_after_test
+    # If setup worked, there should be no mocks
+    refute Taski::TestHelper.mocks_active?
+
+    # Create a mock
+    mock_task(TestHelperFixtures::LeafTask, value: "test")
+    assert Taski::TestHelper.mocks_active?
+
+    # Mock will be cleaned up in teardown
+  end
+
+  # This test runs after the previous one and verifies cleanup happened
+  def test_cleanup_occurred_from_previous_test
+    # Mocks from previous test should be cleaned up
+    refute Taski::TestHelper.mocks_active?
+  end
+end
+
+# Test cleanup on test failure
+class TestCleanupOnFailure < Minitest::Test
+  include Taski::TestHelper::Minitest
+
+  def setup
+    super
+    @mock_was_cleaned = !Taski::TestHelper.mocks_active?
+  end
+
+  def test_cleanup_occurs_even_with_setup_state
+    # This verifies setup ran and cleaned mocks
+    assert @mock_was_cleaned, "setup should have cleaned mocks"
+
+    # Create a mock
+    mock_task(TestHelperFixtures::LeafTask, value: "test")
+    assert Taski::TestHelper.mocks_active?
+  end
+end
+
+# === T035: Test Section API mocking ===
+class TestSectionMocking < Minitest::Test
+  include Taski::TestHelper
+
+  def setup
+    Taski::TestHelper.reset_mocks!
+    Taski::Task.reset!
+  end
+
+  def teardown
+    Taski::TestHelper.reset_mocks!
+  end
+
+  def test_section_can_be_mocked
+    # Mock the Section directly
+    mock_task(TestHelperFixtures::DataSourceSection, data: "mocked_section_data")
+
+    result = TestHelperFixtures::SectionConsumer.processed
+
+    # Section returns mocked value, implementation never runs
+    assert_equal "processed_mocked_section_data", result
+  end
+end
+
+# === T036: Test thread safety ===
+class TestThreadSafety < Minitest::Test
+  include Taski::TestHelper
+
+  def setup
+    Taski::TestHelper.reset_mocks!
+    Taski::Task.reset!
+  end
+
+  def teardown
+    Taski::TestHelper.reset_mocks!
+  end
+
+  def test_mocks_work_across_worker_threads
+    # This tests that mocks registered in the main thread
+    # are accessible from worker threads during task execution
+    mock_task(TestHelperFixtures::LeafTask, value: "thread_safe_value")
+
+    # Execute task with workers (uses thread pool)
+    result = TestHelperFixtures::MiddleTask.result
+
+    assert_equal "middle_thread_safe_value", result
+  end
+
+  def test_concurrent_mock_registration_is_safe
+    # Test that registering mocks concurrently doesn't cause issues
+    threads = 10.times.map do |i|
+      Thread.new do
+        task_class = Class.new(Taski::Task) do
+          exports :value
+          define_method(:run) { @value = "thread_#{i}" }
+        end
+        mock_task(task_class, value: "mocked_#{i}")
+      end
+    end
+
+    threads.each(&:join)
+
+    # All mocks should be registered
+    assert Taski::TestHelper.mocks_active?
+  end
+end
+
+# === T032-T034: Test Selective Mocking (US4) ===
+class TestSelectiveMocking < Minitest::Test
+  include Taski::TestHelper
+
+  def setup
+    Taski::TestHelper.reset_mocks!
+    Taski::Task.reset!
+  end
+
+  def teardown
+    Taski::TestHelper.reset_mocks!
+  end
+
+  # T032: Test unmocked dependencies execute normally
+  def test_unmocked_dependencies_execute_normally
+    # Do not mock LeafTask - it should run normally
+    result = TestHelperFixtures::LeafTask.value
+
+    assert_equal "leaf_result", result
+  end
+
+  # T033: Test mixed mocked and unmocked dependencies work together
+  def test_mixed_mocked_and_unmocked_dependencies
+    # Mock only LeafTask, let MultiExportTask run normally
+    mock_task(TestHelperFixtures::LeafTask, value: "mocked_leaf")
+    # MultiExportTask is NOT mocked
+
+    result = TestHelperFixtures::MultiDependencyTask.combined
+
+    # LeafTask returns mocked value, MultiExportTask runs normally
+    assert_equal "mocked_leaf_first_value", result
+  end
+
+  # T034: Test mock lookup returns nil for unmocked tasks
+  def test_mock_lookup_returns_nil_for_unmocked
+    mock_task(TestHelperFixtures::LeafTask, value: "mocked")
+
+    # LeafTask is mocked
+    refute_nil Taski::TestHelper.mock_for(TestHelperFixtures::LeafTask)
+
+    # MultiExportTask is NOT mocked
+    assert_nil Taski::TestHelper.mock_for(TestHelperFixtures::MultiExportTask)
+  end
+end


### PR DESCRIPTION
## Summary

- Add `Taski::TestHelper` module for mocking task dependencies in unit tests
- `mock_task(TaskClass, key: value)` to mock exported values without running tasks
- `assert_task_accessed` / `refute_task_accessed` for verifying dependency access
- Automatic isolation of indirect dependencies (only direct dependencies need mocking)
- Support for both Minitest and RSpec test frameworks
- Implementation uses Ruby's `prepend` to intercept task execution without modifying production code

## Test plan

- [x] Run `rake test` - all 352 tests pass
- [x] Run `rake standard` - no style violations
- [x] Verify mock_task works with simplified syntax `mock_task(FetchData, users: [1, 2, 3])`

🤖 Generated with [Claude Code](https://claude.com/claude-code)