### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-01-23
+
+### Added
+- `Taski::Env` class for system-managed execution environment information ([#125](https://github.com/ahogappa/taski/pull/125))
+  - Access via `Taski.env.working_directory`, `Taski.env.started_at`, `Taski.env.root_task`
+- `args` and `workers` parameters to `Task.new` for direct task instantiation ([#125](https://github.com/ahogappa/taski/pull/125))
+- `mock_env` helper in `TestHelper` for mocking environment in tests ([#125](https://github.com/ahogappa/taski/pull/125))
+
+### Changed
+- Separate system attributes from `Taski.args` to `Taski.env` ([#125](https://github.com/ahogappa/taski/pull/125))
+  - `Taski.args` now holds only user-defined options passed via `run(args: {...})`
+  - `Taski.env` holds system-managed execution environment (`root_task`, `started_at`, `working_directory`)
+
 ## [0.7.1] - 2026-01-22
 
 ### Added

--- a/lib/taski/version.rb
+++ b/lib/taski/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Taski
-  VERSION = "0.7.1"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
## Summary
- Bump version to 0.8.0
- Update CHANGELOG.md with v0.8.0 release notes

## Changes in v0.8.0

### Added
- `Taski::Env` class for system-managed execution environment information
- `args` and `workers` parameters to `Task.new` for direct task instantiation
- `mock_env` helper in `TestHelper` for mocking environment in tests

### Changed
- Separate system attributes from `Taski.args` to `Taski.env`
  - `Taski.args` now holds only user-defined options
  - `Taski.env` holds system-managed execution environment

## Test plan
- [x] All tests pass (358 runs, 938 assertions, 0 failures)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `Taski::Env` to access system-managed execution environment (working directory, start time, root task).
  * Added `args` and `workers` parameters for direct task instantiation.
  * Added `mock_env` test helper for testing.

* **Changed**
  * System environment now accessible via `Taski.env`; `Taski.args` now contains only user-defined options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->