### PR TITLE
fix: Prioritize environment variable over code settings for progress_mode

### DIFF
--- a/lib/taski.rb
+++ b/lib/taski.rb
@@ -229,9 +229,14 @@ module Taski
   end
 
   # Get the current progress mode (:tree or :simple)
+  # Environment variable TASKI_PROGRESS_MODE takes precedence over code settings.
   # @return [Symbol] The current progress mode
   def self.progress_mode
-    @progress_mode || progress_mode_from_env
+    if ENV["TASKI_PROGRESS_MODE"]
+      progress_mode_from_env
+    else
+      @progress_mode || :tree
+    end
   end
 
   # Set the progress mode (:tree or :simple)

--- a/test/test_simple_progress_display.rb
+++ b/test/test_simple_progress_display.rb
@@ -279,11 +279,12 @@ class TestProgressModeConfiguration < Minitest::Test
     assert_equal :tree, Taski.progress_mode
   end
 
-  def test_api_setting_overrides_environment
+  def test_environment_overrides_api_setting
     ENV["TASKI_PROGRESS_MODE"] = "simple"
     Taski.reset_progress_display!
     Taski.progress_mode = :tree
-    assert_equal :tree, Taski.progress_mode
+    # Environment variable takes precedence over code settings
+    assert_equal :simple, Taski.progress_mode
   end
 
   def test_progress_display_returns_tree_display_by_default


### PR DESCRIPTION
## Summary
- Environment variable `TASKI_PROGRESS_MODE` now takes precedence over code settings (`Taski.progress_mode=`)
- Previously, code settings would override environment variables, which was counterintuitive for CLI usage
- Updated tests to reflect the new behavior

## Test plan
- [x] `rake test` passes
- [x] `rake standard` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)