### PR TITLE
feat: Add Taski.message API for user-facing output

### DIFF
--- a/examples/message_demo.rb
+++ b/examples/message_demo.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Demonstrates Taski.message API
+#
+# Taski.message outputs text to the user without being captured by TaskOutputRouter.
+# Messages are queued during progress display and shown after task completion.
+#
+# Usage:
+#   ruby examples/message_demo.rb
+#   TASKI_FORCE_PROGRESS=1 ruby examples/message_demo.rb  # Force progress display
+
+require_relative "../lib/taski"
+
+class ProcessDataTask < Taski::Task
+  exports :processed_count
+
+  def run
+    puts "Starting data processing..."  # Captured by TaskOutputRouter
+
+    # Simulate processing
+    5.times do |i|
+      puts "Processing batch #{i + 1}/5..."  # Captured
+      sleep 0.3
+    end
+
+    @processed_count = 42
+
+    # These messages bypass TaskOutputRouter and appear after execution
+    Taski.message("Created: /tmp/output.txt")
+    Taski.message("Summary: #{@processed_count} items processed successfully")
+  end
+end
+
+class GenerateReportTask < Taski::Task
+  exports :report_path
+
+  def run
+    # Dependency: ProcessDataTask will be executed first
+    count = ProcessDataTask.processed_count
+    puts "Generating report for #{count} items..."  # Captured
+
+    sleep 0.5
+
+    @report_path = "/tmp/report.pdf"
+
+    Taski.message("Report available at: #{@report_path}")
+  end
+end
+
+puts "=== Taski.message Demo ==="
+puts
+
+GenerateReportTask.run
+
+puts
+puts "=== Done ==="

--- a/lib/taski/execution/execution_context.rb
+++ b/lib/taski/execution/execution_context.rb
@@ -81,12 +81,38 @@ module Taski
         @output_capture = nil
         @original_stdout = nil
         @runtime_dependencies = {}
+        @message_queue = []
       end
 
       # Check if output capture is already active.
       # @return [Boolean] true if capture is active
       def output_capture_active?
         @monitor.synchronize { !@output_capture.nil? }
+      end
+
+      # Queue a message to be displayed after execution completes.
+      # Thread-safe for access from worker threads.
+      #
+      # @param text [String] The message text to queue
+      def queue_message(text)
+        @monitor.synchronize { @message_queue << text }
+      end
+
+      # Flush all queued messages to the given output.
+      # Clears the queue after flushing.
+      #
+      # @param output [IO] The output stream to write messages to
+      def flush_messages(output)
+        messages = @monitor.synchronize { @message_queue.dup.tap { @message_queue.clear } }
+        messages.each { |msg| output.puts(msg) }
+      end
+
+      # Get the original stdout before output capture was set up.
+      # Thread-safe accessor.
+      #
+      # @return [IO, nil] The original stdout or nil if not captured
+      def original_stdout
+        @monitor.synchronize { @original_stdout }
       end
 
       # Set up output capture for inline progress display.

--- a/lib/taski/execution/executor.rb
+++ b/lib/taski/execution/executor.rb
@@ -418,7 +418,15 @@ module Taski
       ensure
         stop_progress_display
         @saved_output_capture = @execution_context.output_capture
+        flush_queued_messages if should_teardown_capture
         teardown_output_capture if should_teardown_capture
+      end
+
+      # Flush queued messages from ExecutionContext to original stdout.
+      # Called after progress display stops to show user messages.
+      def flush_queued_messages
+        output = @execution_context.original_stdout || $stdout
+        @execution_context.flush_messages(output)
       end
 
       def create_default_execution_context

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "stringio"
+
+class TestMessage < Minitest::Test
+  def setup
+    Taski::Task.reset! if defined?(Taski::Task)
+    Taski.reset_progress_display!
+    # Clear any thread-local context
+    Taski::Execution::ExecutionContext.current = nil
+  end
+
+  def teardown
+    Taski.reset_progress_display!
+    Taski::Execution::ExecutionContext.current = nil
+  end
+
+  # ========================================
+  # Unit Tests for ExecutionContext message queue
+  # ========================================
+
+  def test_queue_message_adds_to_queue
+    context = Taski::Execution::ExecutionContext.new
+
+    context.queue_message("Message 1")
+    context.queue_message("Message 2")
+
+    output = StringIO.new
+    context.flush_messages(output)
+
+    assert_equal "Message 1\nMessage 2\n", output.string
+  end
+
+  def test_flush_messages_clears_queue
+    context = Taski::Execution::ExecutionContext.new
+
+    context.queue_message("Test message")
+
+    output1 = StringIO.new
+    context.flush_messages(output1)
+    assert_equal "Test message\n", output1.string
+
+    output2 = StringIO.new
+    context.flush_messages(output2)
+    assert_equal "", output2.string, "Queue should be empty after flush"
+  end
+
+  def test_flush_messages_with_empty_queue
+    context = Taski::Execution::ExecutionContext.new
+    output = StringIO.new
+
+    context.flush_messages(output)
+
+    assert_equal "", output.string
+  end
+
+  def test_original_stdout_accessor
+    context = Taski::Execution::ExecutionContext.new
+    mock_io = StringIO.new
+
+    assert_nil context.original_stdout, "Should be nil before setup"
+
+    original_stdout = $stdout
+    begin
+      context.setup_output_capture(mock_io)
+      assert_equal mock_io, context.original_stdout, "Should return original stdout after setup"
+
+      context.teardown_output_capture
+      assert_nil context.original_stdout, "Should be nil after teardown"
+    ensure
+      $stdout = original_stdout
+    end
+  end
+
+  # ========================================
+  # Taski.message behavior tests
+  # ========================================
+
+  def test_message_without_active_context_outputs_immediately
+    output = StringIO.new
+    original_stdout = $stdout
+
+    begin
+      $stdout = output
+      Taski.message("Direct output")
+    ensure
+      $stdout = original_stdout
+    end
+
+    assert_equal "Direct output\n", output.string
+  end
+
+  def test_message_with_inactive_capture_outputs_immediately
+    context = Taski::Execution::ExecutionContext.new
+    Taski::Execution::ExecutionContext.current = context
+
+    output = StringIO.new
+    original_stdout = $stdout
+
+    begin
+      $stdout = output
+      refute context.output_capture_active?, "Capture should be inactive"
+      Taski.message("Direct output")
+    ensure
+      $stdout = original_stdout
+    end
+
+    assert_equal "Direct output\n", output.string
+  end
+
+  def test_message_with_active_capture_queues_message
+    context = Taski::Execution::ExecutionContext.new
+    Taski::Execution::ExecutionContext.current = context
+    mock_io = StringIO.new
+
+    original_stdout = $stdout
+    begin
+      context.setup_output_capture(mock_io)
+
+      # Message should be queued, not written immediately
+      Taski.message("Queued message")
+
+      # The mock_io should not contain the message yet
+      refute_includes mock_io.string, "Queued message"
+
+      # Flush should output the message
+      output = StringIO.new
+      context.flush_messages(output)
+      assert_equal "Queued message\n", output.string
+    ensure
+      context.teardown_output_capture
+      $stdout = original_stdout
+    end
+  end
+
+  def test_message_thread_safety
+    context = Taski::Execution::ExecutionContext.new
+    Taski::Execution::ExecutionContext.current = context
+    mock_io = StringIO.new
+
+    original_stdout = $stdout
+    begin
+      context.setup_output_capture(mock_io)
+
+      threads = 10.times.map do |i|
+        Thread.new do
+          10.times do |j|
+            # Set context in each thread
+            Taski::Execution::ExecutionContext.current = context
+            Taski.message("Thread #{i} message #{j}")
+          end
+        end
+      end
+
+      threads.each(&:join)
+
+      output = StringIO.new
+      context.flush_messages(output)
+
+      lines = output.string.lines
+      assert_equal 100, lines.size, "Should have 100 messages"
+    ensure
+      context.teardown_output_capture
+      $stdout = original_stdout
+    end
+  end
+
+  # ========================================
+  # Integration test with actual task execution
+  # ========================================
+
+  def test_message_in_task_execution
+    original_stdout = $stdout
+
+    # Use PlainProgressDisplay for easier testing
+    ENV["TASKI_PROGRESS_MODE"] = "plain"
+
+    task_class = Class.new(Taski::Task) do
+      exports :result
+
+      def run
+        Taski.message("Created: /path/to/output.txt")
+        Taski.message("Summary: 42 items processed")
+        @result = "done"
+      end
+    end
+
+    output = StringIO.new
+    begin
+      $stdout = output
+      $stderr = output
+
+      task_class.run
+    ensure
+      $stdout = original_stdout
+      $stderr = STDERR
+      ENV.delete("TASKI_PROGRESS_MODE")
+    end
+
+    # Messages should appear after task completion
+    assert_includes output.string, "Created: /path/to/output.txt"
+    assert_includes output.string, "Summary: 42 items processed"
+  end
+
+  def test_message_order_preserved
+    context = Taski::Execution::ExecutionContext.new
+    Taski::Execution::ExecutionContext.current = context
+    mock_io = StringIO.new
+
+    original_stdout = $stdout
+    begin
+      context.setup_output_capture(mock_io)
+
+      Taski.message("First")
+      Taski.message("Second")
+      Taski.message("Third")
+
+      output = StringIO.new
+      context.flush_messages(output)
+
+      lines = output.string.lines.map(&:chomp)
+      assert_equal %w[First Second Third], lines
+    ensure
+      context.teardown_output_capture
+      $stdout = original_stdout
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `Taski.message(text)` method that allows displaying messages to the user without being captured by TaskOutputRouter
- Messages are queued during execution and displayed after task completion
- When progress display is disabled, messages output immediately

## Changes

- Add message queue to `ExecutionContext` with `queue_message` and `flush_messages` methods
- Add `original_stdout` accessor to `ExecutionContext`
- Add `Taski.message` method that queues or outputs immediately based on context
- Flush queued messages in `Executor` after progress display stops

## Test plan

- [x] Unit tests for `ExecutionContext` message queue
- [x] Integration tests for `Taski.message` behavior
- [x] Example demo script (`examples/message_demo.rb`)
- [x] All existing tests pass

## Usage

```ruby
class MyTask < Taski::Task
  def run
    puts "Processing..."  # Captured by progress display

    Taski.message("Created: /path/to/output.txt")  # Shown after completion
  end
end
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Taski.message API for emitting user messages after task execution.
  * Messages are safely queued during execution and displayed after completion without interfering with output capture.
  * Thread-safe message handling across concurrent task execution.

* **Examples**
  * Added new example demonstrating message API usage with tasks.

* **Tests**
  * Added comprehensive test suite for message queuing and task messaging behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->