### PR TITLE
Release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-01-26
+
+### Added
+- `Taski.message` API for user-facing output during task execution ([#129](https://github.com/ahogappa/taski/pull/129))
+
+### Fixed
+- Count unselected section candidates as completed in SimpleProgressDisplay ([#128](https://github.com/ahogappa/taski/pull/128))
+- Prioritize environment variable over code settings for progress_mode ([#127](https://github.com/ahogappa/taski/pull/127))
+
 ## [0.8.0] - 2026-01-23
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    taski (0.7.1)
+    taski (0.8.1)
       prism (~> 1.4)
       tsort
 

--- a/lib/taski/version.rb
+++ b/lib/taski/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Taski
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end


### PR DESCRIPTION
## Summary
- Bump version to 0.8.1
- Update CHANGELOG.md with changes since v0.8.0

## Changes included in this release

### Added
- `Taski.message` API for user-facing output during task execution (#129)

### Fixed
- Count unselected section candidates as completed in SimpleProgressDisplay (#128)
- Prioritize environment variable over code settings for progress_mode (#127)

## Test plan
- [x] All tests pass (`rake test`)
- [x] Code style check passes (`rake standard`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)