### PR TITLE
chore: release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-01-26
+
+### Fixed
+- Queue `Taski.message` output until progress display stops to prevent interleaved output ([#133](https://github.com/ahogappa/taski/pull/133))
+- Correct task count display in SimpleProgressDisplay ([#132](https://github.com/ahogappa/taski/pull/132))
+
+### Changed
+- Consolidate examples from 15 to 8 files for better maintainability ([#131](https://github.com/ahogappa/taski/pull/131))
+
 ## [0.8.1] - 2026-01-26
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    taski (0.8.1)
+    taski (0.8.2)
       prism (~> 1.4)
       tsort
 

--- a/lib/taski/version.rb
+++ b/lib/taski/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Taski
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 end


### PR DESCRIPTION
## Summary
- Bump version to 0.8.2
- Update CHANGELOG.md with changes since v0.8.1

## Changes included in this release

### Fixed
- Queue `Taski.message` output until progress display stops to prevent interleaved output (#133)
- Correct task count display in SimpleProgressDisplay (#132)

### Changed
- Consolidate examples from 15 to 8 files for better maintainability (#131)

## Test plan
- [x] All tests pass (`rake test`)
- [x] Code style check passes (`rake standard`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)