### PR TITLE
Fix simple progress line wrap issue

### DIFF
--- a/lib/taski/progress/layout/simple.rb
+++ b/lib/taski/progress/layout/simple.rb
@@ -109,10 +109,19 @@ module Taski
         def render_live
           @monitor.synchronize do
             line = build_status_line
+            # Truncate line to terminal width to prevent line wrap
+            max_width = terminal_width - 1  # Leave space for cursor
+            line = line[0, max_width] if line.length > max_width
             # Clear line and write new content
             @output.print "\r\e[K#{line}"
             @output.flush
           end
+        end
+
+        def terminal_width
+          @output.winsize[1]
+        rescue
+          80 # Default fallback
         end
 
         def render_final


### PR DESCRIPTION
## Summary
- Fix simple progress mode displaying multiple lines instead of updating single line
- Truncate progress line to terminal width to prevent line wrap
- Add tests for single-line rendering behavior

## Problem
When running `TASKI_PROGRESS_MODE=simple ruby examples/progress_demo.rb`, the progress line would wrap when exceeding terminal width (80 columns). The `\r\e[K` escape sequences only clear the current line, leaving wrapped text visible.

## Solution
Truncate the progress line to `terminal_width - 1` before output, preventing line wrap and ensuring clean single-line updates.

## Test plan
- [x] Run `bundle exec rake test` - all tests pass
- [x] Run `TASKI_PROGRESS_MODE=simple ruby examples/progress_demo.rb` - progress updates on single line
- [x] Verified with asciinema recordings (before/after)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Live status display now prevents unwanted line wrapping by respecting terminal width constraints

* **Tests**
  * Added tests verifying that live rendering updates properly overwrite previous lines and respect terminal width limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->