### PR TITLE
refactor: rename Template to Theme and improve Layout naming

### DIFF
--- a/lib/taski.rb
+++ b/lib/taski.rb
@@ -10,7 +10,7 @@ require_relative "taski/execution/task_wrapper"
 require_relative "taski/execution/scheduler"
 require_relative "taski/execution/worker_pool"
 require_relative "taski/execution/executor"
-require_relative "taski/progress/layout/plain"
+require_relative "taski/progress/layout/log"
 require_relative "taski/progress/layout/simple"
 require_relative "taski/progress/layout/tree"
 require_relative "taski/args"
@@ -291,8 +291,8 @@ module Taski
     case progress_mode
     when :simple
       Progress::Layout::Simple.new
-    when :plain
-      Progress::Layout::Plain.new
+    when :log
+      Progress::Layout::Log.new
     else
       Progress::Layout::Tree.new
     end
@@ -303,8 +303,8 @@ module Taski
     case ENV["TASKI_PROGRESS_MODE"]
     when "simple"
       :simple
-    when "plain"
-      :plain
+    when "log"
+      :log
     else
       :tree
     end

--- a/lib/taski/progress/layout/log.rb
+++ b/lib/taski/progress/layout/log.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 require_relative "base"
-require_relative "../template/plain"
+require_relative "../theme/plain"
 
 module Taski
   module Progress
     module Layout
-      # Plain layout for non-TTY environments (CI, log files, piped output).
+      # Log layout for non-TTY environments (CI, log files, piped output).
       # Outputs plain text without terminal escape codes.
       #
       # Output format:
@@ -15,10 +15,10 @@ module Taski
       #   [FAIL] TaskName: Error message
       #
       # This replaces the old PlainProgressDisplay class.
-      # Uses Template::Plain by default to ensure no ANSI escape codes in output.
-      class Plain < Base
-        def initialize(output: $stderr, template: nil)
-          template ||= Template::Plain.new
+      # Uses Theme::Plain by default to ensure no ANSI escape codes in output.
+      class Log < Base
+        def initialize(output: $stderr, theme: nil)
+          theme ||= Theme::Plain.new
           super
           @output.sync = true if @output.respond_to?(:sync=)
         end

--- a/lib/taski/progress/layout/simple.rb
+++ b/lib/taski/progress/layout/simple.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "base"
-require_relative "../template/simple"
+require_relative "../theme/compact"
 
 module Taski
   module Progress
@@ -11,9 +11,9 @@ module Taski
       #
       #   ⠹ [3/5] DeployTask | Uploading files...
       #
-      # Customization is done through Template classes:
+      # Customization is done through Theme classes:
       #
-      #   class MyTemplate < Taski::Progress::Template::Base
+      #   class MyTheme < Taski::Progress::Theme::Base
       #     def spinner_frames
       #       %w[🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘]
       #     end
@@ -31,10 +31,10 @@ module Taski
       #     end
       #   end
       #
-      #   layout = Taski::Progress::Layout::Simple.new(template: MyTemplate.new)
+      #   layout = Taski::Progress::Layout::Simple.new(theme: MyTheme.new)
       class Simple < Base
-        def initialize(output: $stdout, template: nil)
-          template ||= Template::Simple.new
+        def initialize(output: $stdout, theme: nil)
+          theme ||= Theme::Compact.new
           super
           @renderer_thread = nil
           @running = false
@@ -70,7 +70,7 @@ module Taski
             loop do
               break unless @running_mutex.synchronize { @running }
               render_live
-              sleep @template.render_interval
+              sleep @theme.render_interval
             end
           end
         end

--- a/lib/taski/progress/layout/theme_drop.rb
+++ b/lib/taski/progress/layout/theme_drop.rb
@@ -5,45 +5,45 @@ require "liquid"
 module Taski
   module Progress
     module Layout
-      # Liquid Drop for Template to enable method access from filters/tags.
-      # Wraps a Template instance and delegates color/icon/spinner methods.
+      # Liquid Drop for Theme to enable method access from filters/tags.
+      # Wraps a Theme instance and delegates color/icon/spinner methods.
       #
       # @example Using in Liquid context
-      #   drop = TemplateDrop.new(template)
-      #   Liquid::Template.parse("{{ template.color_red }}")
-      #                   .render("template" => drop)
-      class TemplateDrop < Liquid::Drop
-        def initialize(template)
-          @template = template
+      #   drop = ThemeDrop.new(theme)
+      #   Liquid::Template.parse("{{ theme.color_red }}")
+      #                   .render("theme" => drop)
+      class ThemeDrop < Liquid::Drop
+        def initialize(theme)
+          @theme = theme
         end
 
         # Color methods
-        def color_red = @template.color_red
-        def color_green = @template.color_green
-        def color_yellow = @template.color_yellow
-        def color_dim = @template.color_dim
-        def color_reset = @template.color_reset
+        def color_red = @theme.color_red
+        def color_green = @theme.color_green
+        def color_yellow = @theme.color_yellow
+        def color_dim = @theme.color_dim
+        def color_reset = @theme.color_reset
 
         # Spinner settings
-        def spinner_frames = @template.spinner_frames
-        def spinner_interval = @template.spinner_interval
-        def render_interval = @template.render_interval
+        def spinner_frames = @theme.spinner_frames
+        def spinner_interval = @theme.spinner_interval
+        def render_interval = @theme.render_interval
 
         # Status icons
-        def icon_success = @template.icon_success
-        def icon_failure = @template.icon_failure
-        def icon_pending = @template.icon_pending
+        def icon_success = @theme.icon_success
+        def icon_failure = @theme.icon_failure
+        def icon_pending = @theme.icon_pending
 
         # Formatting methods (used by filters)
-        def format_count(count) = @template.format_count(count)
-        def format_duration(ms) = @template.format_duration(ms)
+        def format_count(count) = @theme.format_count(count)
+        def format_duration(ms) = @theme.format_duration(ms)
 
         # List truncation settings
-        def truncate_list_separator = @template.truncate_list_separator
-        def truncate_list_suffix = @template.truncate_list_suffix
+        def truncate_list_separator = @theme.truncate_list_separator
+        def truncate_list_suffix = @theme.truncate_list_suffix
 
         # Text truncation settings
-        def truncate_text_suffix = @template.truncate_text_suffix
+        def truncate_text_suffix = @theme.truncate_text_suffix
       end
 
       # Base class for Liquid Drops with dynamic property access.

--- a/lib/taski/progress/layout/tree.rb
+++ b/lib/taski/progress/layout/tree.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "base"
-require_relative "../template/tree"
+require_relative "../theme/detail"
 
 module Taski
   module Progress
@@ -24,14 +24,14 @@ module Taski
       #   └── ✓ RunSystemCommand (200ms)
       #
       # The tree structure (prefixes) is added by this Layout.
-      # The task content (icons, names, duration) comes from the Template.
+      # The task content (icons, names, duration) comes from the Theme.
       #
-      # This demonstrates the Template/Layout separation:
-      # - Template defines "what one line looks like" (icons, colors, formatting)
+      # This demonstrates the Theme/Layout separation:
+      # - Theme defines "what one line looks like" (icons, colors, formatting)
       # - Layout defines "how lines are arranged" (tree structure, prefixes)
       #
-      # @example Using with Template::Default
-      #   layout = Taski::Progress::Layout::Tree.new(template: Taski::Progress::Template::Default.new)
+      # @example Using with Theme::Default
+      #   layout = Taski::Progress::Layout::Tree.new(theme: Taski::Progress::Theme::Default.new)
       class Tree < Base
         # Tree connector characters
         BRANCH = "├── "
@@ -39,8 +39,8 @@ module Taski
         VERTICAL = "│   "
         SPACE = "    "
 
-        def initialize(output: $stderr, template: nil)
-          template ||= Template::Tree.new
+        def initialize(output: $stderr, theme: nil)
+          theme ||= Theme::Detail.new
           super
           @tree_nodes = {}
           @node_depths = {}
@@ -130,7 +130,7 @@ module Taski
             loop do
               break unless @running_mutex.synchronize { @running }
               render_live
-              sleep @template.render_interval
+              sleep @theme.render_interval
             end
           end
         end

--- a/lib/taski/progress/theme/base.rb
+++ b/lib/taski/progress/theme/base.rb
@@ -2,26 +2,26 @@
 
 module Taski
   module Progress
-    module Template
-      # Base class for template definitions.
-      # Template classes are thin layers that only return Liquid template strings.
+    module Theme
+      # Base class for theme definitions.
+      # Theme classes are thin layers that only return Liquid template strings.
       # Rendering (Liquid parsing) is handled by Layout classes.
       #
-      # Templates have access to two Drop objects:
+      # Themes have access to two Drop objects:
       #   task: Task-specific info (name, state, duration, error_message, group_name, stdout)
       #   execution: Execution-level info (state, pending_count, done_count, completed_count,
       #              failed_count, total_count, total_duration, root_task_name, task_names)
       #
       # Use {% if variable %} to conditionally render when a value is present.
       #
-      # @example Custom template
-      #   class MyTemplate < Taski::Progress::Template::Base
+      # @example Custom theme
+      #   class MyTheme < Taski::Progress::Theme::Base
       #     def task_start
       #       "Starting {{ task.name }}..."
       #     end
       #   end
       #
-      #   layout = Taski::Progress::Layout::Plain.new(template: MyTemplate.new)
+      #   layout = Taski::Progress::Layout::Log.new(theme: MyTheme.new)
       class Base
         # === Task lifecycle templates ===
 

--- a/lib/taski/progress/theme/compact.rb
+++ b/lib/taski/progress/theme/compact.rb
@@ -4,8 +4,8 @@ require_relative "default"
 
 module Taski
   module Progress
-    module Template
-      # Simple template for TTY environments with single-line progress display.
+    module Theme
+      # Compact theme for TTY environments with single-line progress display.
       # Provides spinner animation, colored icons, and status formatting.
       #
       # Output format:
@@ -14,18 +14,18 @@ module Taski
       #
       # @example Usage
       #   layout = Taski::Progress::Layout::Simple.new(
-      #     template: Taski::Progress::Template::Simple.new
+      #     theme: Taski::Progress::Theme::Compact.new
       #   )
       #
       # @example Custom spinner frames
-      #   class MoonTemplate < Taski::Progress::Template::Simple
+      #   class MoonTheme < Taski::Progress::Theme::Compact
       #     def spinner_frames
       #       %w[🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘]
       #     end
       #   end
       #
-      # @example Custom status template
-      #   class JapaneseTemplate < Taski::Progress::Template::Simple
+      # @example Custom status theme
+      #   class JapaneseTheme < Taski::Progress::Theme::Compact
       #     def format_count(count)
       #       "#{count}件"
       #     end
@@ -34,7 +34,7 @@ module Taski
       #       '{% icon %} {{ execution.done_count | format_count }}完了 ({{ execution.total_duration | format_duration }})'
       #     end
       #   end
-      class Simple < Default
+      class Compact < Default
         # Inherits ANSI colors from Base via Default.
         # Adds spinner and icons for TTY environments.
 

--- a/lib/taski/progress/theme/default.rb
+++ b/lib/taski/progress/theme/default.rb
@@ -4,19 +4,19 @@ require_relative "base"
 
 module Taski
   module Progress
-    module Template
-      # Default template inheriting from Template::Base.
+    module Theme
+      # Default theme inheriting from Theme::Base.
       #
-      # Note: Template::Base provides ANSI color helper methods (color_red,
+      # Note: Theme::Base provides ANSI color helper methods (color_red,
       # color_green, etc.) which return escape codes by default. If Liquid
       # templates or filters use these methods, output may contain escape codes.
       #
       # For guaranteed plain text output without any terminal escape codes,
-      # use Template::Plain instead, which overrides all color methods to
+      # use Theme::Plain instead, which overrides all color methods to
       # return empty strings.
       #
-      # @see Taski::Progress::Template::Base Base class with color helpers
-      # @see Taski::Progress::Template::Plain Plain output without escape codes
+      # @see Taski::Progress::Theme::Base Base class with color helpers
+      # @see Taski::Progress::Theme::Plain Plain output without escape codes
       class Default < Base
         # Inherits all methods from Base.
       end

--- a/lib/taski/progress/theme/detail.rb
+++ b/lib/taski/progress/theme/detail.rb
@@ -4,8 +4,8 @@ require_relative "default"
 
 module Taski
   module Progress
-    module Template
-      # Tree template for TTY environments with tree-structured progress display.
+    module Theme
+      # Detail theme for rich progress display with spinner and icons.
       # Provides spinner animation, colored icons for task states.
       #
       # Output format:
@@ -15,9 +15,9 @@ module Taski
       #
       # @example Usage
       #   layout = Taski::Progress::Layout::Tree.new(
-      #     template: Taski::Progress::Template::Tree.new
+      #     theme: Taski::Progress::Theme::Detail.new
       #   )
-      class Tree < Default
+      class Detail < Default
         # Task pending with icon
         def task_pending
           "{% icon %} {{ task.name | short_name }}"

--- a/lib/taski/progress/theme/plain.rb
+++ b/lib/taski/progress/theme/plain.rb
@@ -4,13 +4,13 @@ require_relative "default"
 
 module Taski
   module Progress
-    module Template
-      # Plain template for non-TTY environments (CI, log files, piped output).
+    module Theme
+      # Plain theme for non-TTY environments (CI, log files, piped output).
       # Outputs plain text without terminal escape codes or colors.
       #
       # @example Usage
-      #   layout = Taski::Progress::Layout::Plain.new(
-      #     template: Taski::Progress::Template::Plain.new
+      #   layout = Taski::Progress::Layout::Log.new(
+      #     theme: Taski::Progress::Theme::Plain.new
       #   )
       class Plain < Default
         # === Color configuration (disabled for plain output) ===

--- a/test/test_layout_log.rb
+++ b/test/test_layout_log.rb
@@ -2,12 +2,12 @@
 
 require "test_helper"
 require "stringio"
-require "taski/progress/layout/plain"
+require "taski/progress/layout/log"
 
-class TestLayoutPlain < Minitest::Test
+class TestLayoutLog < Minitest::Test
   def setup
     @output = StringIO.new
-    @layout = Taski::Progress::Layout::Plain.new(output: @output)
+    @layout = Taski::Progress::Layout::Log.new(output: @output)
   end
 
   # === Task lifecycle output ===
@@ -179,11 +179,11 @@ class TestLayoutPlain < Minitest::Test
     assert_includes @output.string, "[DONE] MyTask (1.5s)"
   end
 
-  # === Custom template ===
+  # === Custom theme ===
 
-  def test_uses_custom_template
-    custom_template = CustomTestTemplate.new
-    layout = Taski::Progress::Layout::Plain.new(output: @output, template: custom_template)
+  def test_uses_custom_theme
+    custom_theme = CustomTestTheme.new
+    layout = Taski::Progress::Layout::Log.new(output: @output, theme: custom_theme)
 
     task_class = stub_task_class("MyTask")
     layout.start
@@ -201,7 +201,7 @@ class TestLayoutPlain < Minitest::Test
     klass
   end
 
-  class CustomTestTemplate < Taski::Progress::Template::Base
+  class CustomTestTheme < Taski::Progress::Theme::Base
     def task_start
       "CUSTOM START {{ task.name }}"
     end

--- a/test/test_layout_simple.rb
+++ b/test/test_layout_simple.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 require "stringio"
 require "taski/progress/layout/simple"
-require "taski/progress/template/simple"
+require "taski/progress/theme/compact"
 
 class TestLayoutSimple < Minitest::Test
   def setup
@@ -87,7 +87,7 @@ class TestLayoutSimple < Minitest::Test
 
   def test_spinner_frames_loaded_from_template
     # Spinner frames are accessed via template
-    template = @layout.instance_variable_get(:@template)
+    template = @layout.instance_variable_get(:@theme)
     assert_equal 10, template.spinner_frames.size
   end
 
@@ -126,14 +126,14 @@ class TestLayoutSimple < Minitest::Test
   # === Icon and color configuration from Template ===
 
   def test_icons_available_via_template
-    template = @layout.instance_variable_get(:@template)
+    template = @layout.instance_variable_get(:@theme)
     assert_equal "✓", template.icon_success
     assert_equal "✗", template.icon_failure
     assert_equal "○", template.icon_pending
   end
 
   def test_colors_available_via_template
-    template = @layout.instance_variable_get(:@template)
+    template = @layout.instance_variable_get(:@theme)
     assert_equal "\e[32m", template.color_green
     assert_equal "\e[31m", template.color_red
     assert_equal "\e[33m", template.color_yellow
@@ -160,39 +160,39 @@ class TestLayoutSimpleWithCustomTemplate < Minitest::Test
   # === Custom spinner frames ===
 
   def test_uses_custom_spinner_frames_from_template
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def spinner_frames
         %w[🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘]
       end
     end.new
 
-    layout = Taski::Progress::Layout::Simple.new(output: @output, template: custom_template)
+    layout = Taski::Progress::Layout::Simple.new(output: @output, theme: custom_theme)
 
     # Verify the layout accesses the custom spinner frames via template
-    template = layout.instance_variable_get(:@template)
+    template = layout.instance_variable_get(:@theme)
     assert_equal %w[🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘], template.spinner_frames
   end
 
   # === Custom render interval ===
 
   def test_uses_custom_render_interval_from_template
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def render_interval
         0.2
       end
     end.new
 
-    layout = Taski::Progress::Layout::Simple.new(output: @output, template: custom_template)
+    layout = Taski::Progress::Layout::Simple.new(output: @output, theme: custom_theme)
 
     # Verify the layout accesses render interval via template
-    template = layout.instance_variable_get(:@template)
+    template = layout.instance_variable_get(:@theme)
     assert_in_delta 0.2, template.render_interval, 0.001
   end
 
   # === Custom icons ===
 
   def test_uses_custom_icons_in_final_output
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def icon_success
         "🎉"
       end
@@ -202,7 +202,7 @@ class TestLayoutSimpleWithCustomTemplate < Minitest::Test
       end
     end.new
 
-    layout = Taski::Progress::Layout::Simple.new(output: @output, template: custom_template)
+    layout = Taski::Progress::Layout::Simple.new(output: @output, theme: custom_theme)
     task_class = stub_task_class("MyTask")
     layout.register_task(task_class)
     layout.start
@@ -215,7 +215,7 @@ class TestLayoutSimpleWithCustomTemplate < Minitest::Test
   end
 
   def test_uses_custom_failure_icon_in_final_output
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def icon_failure
         "💥"
       end
@@ -225,7 +225,7 @@ class TestLayoutSimpleWithCustomTemplate < Minitest::Test
       end
     end.new
 
-    layout = Taski::Progress::Layout::Simple.new(output: @output, template: custom_template)
+    layout = Taski::Progress::Layout::Simple.new(output: @output, theme: custom_theme)
     task_class = stub_task_class("FailedTask")
     layout.register_task(task_class)
     layout.start
@@ -241,13 +241,13 @@ class TestLayoutSimpleWithCustomTemplate < Minitest::Test
   # === Custom execution templates ===
 
   def test_uses_custom_execution_complete_template
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def execution_complete
         "{% icon %} Finished {{ execution.completed_count }} tasks in {{ execution.total_duration | format_duration }}"
       end
     end.new
 
-    layout = Taski::Progress::Layout::Simple.new(output: @output, template: custom_template)
+    layout = Taski::Progress::Layout::Simple.new(output: @output, theme: custom_theme)
     task_class = stub_task_class("MyTask")
     layout.register_task(task_class)
     layout.start
@@ -260,7 +260,7 @@ class TestLayoutSimpleWithCustomTemplate < Minitest::Test
   # === No constants needed with template ===
 
   def test_layout_does_not_require_constants_when_using_template
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def spinner_frames
         %w[A B C]
       end
@@ -299,7 +299,7 @@ class TestLayoutSimpleWithCustomTemplate < Minitest::Test
       end
     end.new
 
-    layout = Taski::Progress::Layout::Simple.new(output: @output, template: custom_template)
+    layout = Taski::Progress::Layout::Simple.new(output: @output, theme: custom_theme)
     task_class = stub_task_class("TestTask")
     layout.register_task(task_class)
     layout.start

--- a/test/test_layout_tree.rb
+++ b/test/test_layout_tree.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 require "stringio"
 require "taski/progress/layout/tree"
-require "taski/progress/template/default"
+require "taski/progress/theme/default"
 
 class TestLayoutTree < Minitest::Test
   def setup
@@ -16,9 +16,9 @@ class TestLayoutTree < Minitest::Test
     assert_instance_of Taski::Progress::Layout::Tree, layout
   end
 
-  def test_can_initialize_with_custom_template
-    template = Taski::Progress::Template::Default.new
-    layout = Taski::Progress::Layout::Tree.new(output: @output, template: template)
+  def test_can_initialize_with_custom_theme
+    template = Taski::Progress::Theme::Default.new
+    layout = Taski::Progress::Layout::Tree.new(output: @output, theme: template)
     assert_instance_of Taski::Progress::Layout::Tree, layout
   end
 
@@ -64,7 +64,7 @@ class TestLayoutTreeRendering < Minitest::Test
     @layout = Taski::Progress::Layout::Tree.new(output: @output)
   end
 
-  # Test that Layout::Tree uses Template::Tree by default with icons/spinner
+  # Test that Layout::Tree uses Theme::Detail by default with icons/spinner
 
   def test_outputs_task_start_with_spinner
     task_class = stub_task_class("MyTask")
@@ -73,7 +73,7 @@ class TestLayoutTreeRendering < Minitest::Test
     @layout.update_task(task_class, state: :running)
     @layout.stop
 
-    # Template::Tree uses spinner for running tasks
+    # Theme::Detail uses spinner for running tasks
     assert_includes @output.string, "⠋ MyTask"
   end
 
@@ -85,7 +85,7 @@ class TestLayoutTreeRendering < Minitest::Test
     @layout.update_task(task_class, state: :completed, duration: 123)
     @layout.stop
 
-    # Template::Tree uses ✓ icon for completed tasks
+    # Theme::Detail uses ✓ icon for completed tasks
     assert_includes @output.string, "✓"
     assert_includes @output.string, "MyTask"
     assert_includes @output.string, "(123ms)"
@@ -99,7 +99,7 @@ class TestLayoutTreeRendering < Minitest::Test
     @layout.update_task(task_class, state: :failed, error: StandardError.new("Something went wrong"))
     @layout.stop
 
-    # Template::Tree uses ✗ icon for failed tasks
+    # Theme::Detail uses ✗ icon for failed tasks
     assert_includes @output.string, "✗"
     assert_includes @output.string, "MyTask"
     assert_includes @output.string, "Something went wrong"
@@ -276,7 +276,7 @@ class TestLayoutTreeTaskContent < Minitest::Test
     @layout.register_task(task_class)
 
     content = @layout.send(:build_task_content, task_class)
-    # Template::Tree uses ○ icon for pending
+    # Theme::Detail uses ○ icon for pending
     assert_includes content, "○"
     assert_includes content, "MyTask"
   end
@@ -287,7 +287,7 @@ class TestLayoutTreeTaskContent < Minitest::Test
     @layout.update_task(task_class, state: :running)
 
     content = @layout.send(:build_task_content, task_class)
-    # Template::Tree uses spinner for running
+    # Theme::Detail uses spinner for running
     assert_includes content, "⠋"
     assert_includes content, "MyTask"
   end
@@ -298,7 +298,7 @@ class TestLayoutTreeTaskContent < Minitest::Test
     @layout.update_task(task_class, state: :completed, duration: 100)
 
     content = @layout.send(:build_task_content, task_class)
-    # Template::Tree uses ✓ icon for completed
+    # Theme::Detail uses ✓ icon for completed
     assert_includes content, "✓"
     assert_includes content, "MyTask"
     assert_includes content, "(100ms)"
@@ -310,7 +310,7 @@ class TestLayoutTreeTaskContent < Minitest::Test
     @layout.update_task(task_class, state: :failed, error: StandardError.new("Something went wrong"))
 
     content = @layout.send(:build_task_content, task_class)
-    # Template::Tree uses ✗ icon for failed
+    # Theme::Detail uses ✗ icon for failed
     assert_includes content, "✗"
     assert_includes content, "MyTask"
     assert_includes content, "Something went wrong"
@@ -332,14 +332,14 @@ class TestLayoutTreeWithCustomTemplate < Minitest::Test
     @output = StringIO.new
   end
 
-  def test_uses_custom_template_task_start
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+  def test_uses_custom_theme_task_start
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def task_start
         "[BEGIN] {{ task.name }}"
       end
     end.new
 
-    layout = Taski::Progress::Layout::Tree.new(output: @output, template: custom_template)
+    layout = Taski::Progress::Layout::Tree.new(output: @output, theme: custom_theme)
     task_class = stub_task_class("MyTask")
     layout.register_task(task_class)
     layout.start
@@ -349,14 +349,14 @@ class TestLayoutTreeWithCustomTemplate < Minitest::Test
     assert_includes @output.string, "[BEGIN] MyTask"
   end
 
-  def test_uses_custom_template_task_success
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+  def test_uses_custom_theme_task_success
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def task_success
         "[OK] {{ task.name }}"
       end
     end.new
 
-    layout = Taski::Progress::Layout::Tree.new(output: @output, template: custom_template)
+    layout = Taski::Progress::Layout::Tree.new(output: @output, theme: custom_theme)
     task_class = stub_task_class("MyTask")
     layout.register_task(task_class)
     layout.start
@@ -366,14 +366,14 @@ class TestLayoutTreeWithCustomTemplate < Minitest::Test
     assert_includes @output.string, "[OK] MyTask"
   end
 
-  def test_tree_prefix_with_custom_template
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+  def test_tree_prefix_with_custom_theme
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def task_start
         "=> {{ task.name }}"
       end
     end.new
 
-    layout = Taski::Progress::Layout::Tree.new(output: @output, template: custom_template)
+    layout = Taski::Progress::Layout::Tree.new(output: @output, theme: custom_theme)
 
     child = stub_task_class("ChildTask")
     parent = stub_task_class_with_deps("ParentTask", [child])

--- a/test/test_liquid_filters.rb
+++ b/test/test_liquid_filters.rb
@@ -3,8 +3,8 @@
 require "minitest/autorun"
 require "liquid"
 require_relative "../lib/taski/progress/layout/filters"
-require_relative "../lib/taski/progress/layout/template_drop"
-require_relative "../lib/taski/progress/template/base"
+require_relative "../lib/taski/progress/layout/theme_drop"
+require_relative "../lib/taski/progress/theme/base"
 
 class TestLiquidFilters < Minitest::Test
   def setup
@@ -13,9 +13,9 @@ class TestLiquidFilters < Minitest::Test
     end
   end
 
-  def test_red_filter_with_template_drop
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+  def test_red_filter_with_theme_drop
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{{ text | red }}", environment: @environment)
     result = liquid_template.render("text" => "error", "template" => drop)
@@ -23,9 +23,9 @@ class TestLiquidFilters < Minitest::Test
     assert_equal "\e[31merror\e[0m", result
   end
 
-  def test_green_filter_with_template_drop
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+  def test_green_filter_with_theme_drop
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{{ text | green }}", environment: @environment)
     result = liquid_template.render("text" => "success", "template" => drop)
@@ -33,9 +33,9 @@ class TestLiquidFilters < Minitest::Test
     assert_equal "\e[32msuccess\e[0m", result
   end
 
-  def test_yellow_filter_with_template_drop
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+  def test_yellow_filter_with_theme_drop
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{{ text | yellow }}", environment: @environment)
     result = liquid_template.render("text" => "warning", "template" => drop)
@@ -43,9 +43,9 @@ class TestLiquidFilters < Minitest::Test
     assert_equal "\e[33mwarning\e[0m", result
   end
 
-  def test_dim_filter_with_template_drop
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+  def test_dim_filter_with_theme_drop
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{{ text | dim }}", environment: @environment)
     result = liquid_template.render("text" => "subtle", "template" => drop)
@@ -53,36 +53,36 @@ class TestLiquidFilters < Minitest::Test
     assert_equal "\e[2msubtle\e[0m", result
   end
 
-  def test_red_filter_without_template_drop_uses_default
+  def test_red_filter_without_theme_drop_uses_default
     liquid_template = Liquid::Template.parse("{{ text | red }}", environment: @environment)
     result = liquid_template.render("text" => "error")
 
     assert_equal "\e[31merror\e[0m", result
   end
 
-  def test_green_filter_without_template_drop_uses_default
+  def test_green_filter_without_theme_drop_uses_default
     liquid_template = Liquid::Template.parse("{{ text | green }}", environment: @environment)
     result = liquid_template.render("text" => "success")
 
     assert_equal "\e[32msuccess\e[0m", result
   end
 
-  def test_yellow_filter_without_template_drop_uses_default
+  def test_yellow_filter_without_theme_drop_uses_default
     liquid_template = Liquid::Template.parse("{{ text | yellow }}", environment: @environment)
     result = liquid_template.render("text" => "warning")
 
     assert_equal "\e[33mwarning\e[0m", result
   end
 
-  def test_dim_filter_without_template_drop_uses_default
+  def test_dim_filter_without_theme_drop_uses_default
     liquid_template = Liquid::Template.parse("{{ text | dim }}", environment: @environment)
     result = liquid_template.render("text" => "subtle")
 
     assert_equal "\e[2msubtle\e[0m", result
   end
 
-  def test_filter_uses_custom_template_colors
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+  def test_filter_uses_custom_theme_colors
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def color_red
         "\e[91m"  # bright red
       end
@@ -92,7 +92,7 @@ class TestLiquidFilters < Minitest::Test
       end
     end.new
 
-    drop = Taski::Progress::Layout::TemplateDrop.new(custom_template)
+    drop = Taski::Progress::Layout::ThemeDrop.new(custom_theme)
 
     liquid_template = Liquid::Template.parse("{{ text | red }}", environment: @environment)
     result = liquid_template.render("text" => "custom", "template" => drop)
@@ -101,8 +101,8 @@ class TestLiquidFilters < Minitest::Test
   end
 
   def test_multiple_filters_in_template
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse(
       "{{ status | green }} - {{ message | dim }}",
@@ -119,9 +119,9 @@ class TestLiquidFilters < Minitest::Test
 
   # === format_count filter tests ===
 
-  def test_format_count_with_template_drop
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+  def test_format_count_with_theme_drop
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{{ count | format_count }}", environment: @environment)
     result = liquid_template.render("count" => 5, "template" => drop)
@@ -129,21 +129,21 @@ class TestLiquidFilters < Minitest::Test
     assert_equal "5", result
   end
 
-  def test_format_count_without_template_drop_uses_default
+  def test_format_count_without_theme_drop_uses_default
     liquid_template = Liquid::Template.parse("{{ count | format_count }}", environment: @environment)
     result = liquid_template.render("count" => 10)
 
     assert_equal "10", result
   end
 
-  def test_format_count_with_custom_template
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+  def test_format_count_with_custom_theme
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def format_count(count)
         "#{count}件"
       end
     end.new
 
-    drop = Taski::Progress::Layout::TemplateDrop.new(custom_template)
+    drop = Taski::Progress::Layout::ThemeDrop.new(custom_theme)
 
     liquid_template = Liquid::Template.parse("{{ count | format_count }}", environment: @environment)
     result = liquid_template.render("count" => 3, "template" => drop)
@@ -152,8 +152,8 @@ class TestLiquidFilters < Minitest::Test
   end
 
   def test_format_count_in_progress_display
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse(
       "[{{ done | format_count }}/{{ total | format_count }}]",
@@ -167,8 +167,8 @@ class TestLiquidFilters < Minitest::Test
   # === format_duration filter tests ===
 
   def test_format_duration_milliseconds
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{{ duration | format_duration }}", environment: @environment)
     result = liquid_template.render("duration" => 500, "template" => drop)
@@ -177,8 +177,8 @@ class TestLiquidFilters < Minitest::Test
   end
 
   def test_format_duration_seconds
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{{ duration | format_duration }}", environment: @environment)
     result = liquid_template.render("duration" => 1500, "template" => drop)
@@ -186,21 +186,21 @@ class TestLiquidFilters < Minitest::Test
     assert_equal "1.5s", result
   end
 
-  def test_format_duration_without_template_drop_uses_default
+  def test_format_duration_without_theme_drop_uses_default
     liquid_template = Liquid::Template.parse("{{ duration | format_duration }}", environment: @environment)
     result = liquid_template.render("duration" => 2000)
 
     assert_equal "2.0s", result
   end
 
-  def test_format_duration_with_custom_template
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+  def test_format_duration_with_custom_theme
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def format_duration(ms)
         "#{ms}ミリ秒"
       end
     end.new
 
-    drop = Taski::Progress::Layout::TemplateDrop.new(custom_template)
+    drop = Taski::Progress::Layout::ThemeDrop.new(custom_theme)
 
     liquid_template = Liquid::Template.parse("{{ duration | format_duration }}", environment: @environment)
     result = liquid_template.render("duration" => 100, "template" => drop)
@@ -218,8 +218,8 @@ class TestLiquidFilters < Minitest::Test
   # === truncate_list filter tests ===
 
   def test_truncate_list_with_array
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{{ items | truncate_list: 3 }}", environment: @environment)
     result = liquid_template.render("items" => %w[A B C D E], "template" => drop)
@@ -228,8 +228,8 @@ class TestLiquidFilters < Minitest::Test
   end
 
   def test_truncate_list_without_truncation
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{{ items | truncate_list: 3 }}", environment: @environment)
     result = liquid_template.render("items" => %w[A B], "template" => drop)
@@ -238,8 +238,8 @@ class TestLiquidFilters < Minitest::Test
   end
 
   def test_truncate_list_exact_limit
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{{ items | truncate_list: 3 }}", environment: @environment)
     result = liquid_template.render("items" => %w[A B C], "template" => drop)
@@ -248,7 +248,7 @@ class TestLiquidFilters < Minitest::Test
   end
 
   def test_truncate_list_with_custom_separator_and_suffix
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def truncate_list_separator
         " / "
       end
@@ -258,7 +258,7 @@ class TestLiquidFilters < Minitest::Test
       end
     end.new
 
-    drop = Taski::Progress::Layout::TemplateDrop.new(custom_template)
+    drop = Taski::Progress::Layout::ThemeDrop.new(custom_theme)
 
     liquid_template = Liquid::Template.parse("{{ items | truncate_list: 2 }}", environment: @environment)
     result = liquid_template.render("items" => %w[A B C D], "template" => drop)
@@ -283,8 +283,8 @@ class TestLiquidFilters < Minitest::Test
   # === truncate_text filter tests ===
 
   def test_truncate_text_within_limit
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{{ text | truncate_text: 40 }}", environment: @environment)
     result = liquid_template.render("text" => "Short text", "template" => drop)
@@ -293,8 +293,8 @@ class TestLiquidFilters < Minitest::Test
   end
 
   def test_truncate_text_exceeds_limit
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{{ text | truncate_text: 20 }}", environment: @environment)
     result = liquid_template.render("text" => "This is a very long text that should be truncated", "template" => drop)
@@ -303,8 +303,8 @@ class TestLiquidFilters < Minitest::Test
   end
 
   def test_truncate_text_exact_limit
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{{ text | truncate_text: 10 }}", environment: @environment)
     result = liquid_template.render("text" => "0123456789", "template" => drop)
@@ -320,13 +320,13 @@ class TestLiquidFilters < Minitest::Test
   end
 
   def test_truncate_text_with_custom_suffix
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def truncate_text_suffix
         "…"
       end
     end.new
 
-    drop = Taski::Progress::Layout::TemplateDrop.new(custom_template)
+    drop = Taski::Progress::Layout::ThemeDrop.new(custom_theme)
 
     liquid_template = Liquid::Template.parse("{{ text | truncate_text: 15 }}", environment: @environment)
     result = liquid_template.render("text" => "This is a long text to truncate", "template" => drop)
@@ -334,7 +334,7 @@ class TestLiquidFilters < Minitest::Test
     assert_equal "This is a long…", result
   end
 
-  def test_truncate_text_without_template_drop_uses_default
+  def test_truncate_text_without_theme_drop_uses_default
     liquid_template = Liquid::Template.parse("{{ text | truncate_text: 15 }}", environment: @environment)
     result = liquid_template.render("text" => "This is a long text to truncate")
 

--- a/test/test_liquid_tags.rb
+++ b/test/test_liquid_tags.rb
@@ -3,8 +3,8 @@
 require "minitest/autorun"
 require "liquid"
 require_relative "../lib/taski/progress/layout/tags"
-require_relative "../lib/taski/progress/layout/template_drop"
-require_relative "../lib/taski/progress/template/base"
+require_relative "../lib/taski/progress/layout/theme_drop"
+require_relative "../lib/taski/progress/theme/base"
 
 class TestLiquidTags < Minitest::Test
   def setup
@@ -19,8 +19,8 @@ class TestLiquidTags < Minitest::Test
   end
 
   def test_spinner_tag_renders_first_frame_by_default
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{% spinner %}", environment: @environment)
     result = liquid_template.render("template" => drop)
@@ -30,8 +30,8 @@ class TestLiquidTags < Minitest::Test
   end
 
   def test_spinner_tag_uses_spinner_index_from_context
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{% spinner %}", environment: @environment)
     result = liquid_template.render("template" => drop, "spinner_index" => 3)
@@ -42,8 +42,8 @@ class TestLiquidTags < Minitest::Test
   end
 
   def test_spinner_tag_wraps_around_when_index_exceeds_frames
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{% spinner %}", environment: @environment)
     result = liquid_template.render("template" => drop, "spinner_index" => 10)
@@ -53,13 +53,13 @@ class TestLiquidTags < Minitest::Test
   end
 
   def test_spinner_tag_uses_custom_frames_from_template
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def spinner_frames
         %w[| / - \\]
       end
     end.new
 
-    drop = Taski::Progress::Layout::TemplateDrop.new(custom_template)
+    drop = Taski::Progress::Layout::ThemeDrop.new(custom_theme)
 
     liquid_template = Liquid::Template.parse("{% spinner %}", environment: @environment)
 
@@ -72,7 +72,7 @@ class TestLiquidTags < Minitest::Test
     assert_equal "-", result2
   end
 
-  def test_spinner_tag_without_template_drop_uses_default
+  def test_spinner_tag_without_theme_drop_uses_default
     liquid_template = Liquid::Template.parse("{% spinner %}", environment: @environment)
     result = liquid_template.render({})
 
@@ -81,8 +81,8 @@ class TestLiquidTags < Minitest::Test
   end
 
   def test_spinner_tag_can_be_combined_with_text
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse(
       "{% spinner %} Loading {{ task_name }}...",
@@ -104,8 +104,8 @@ class TestLiquidTags < Minitest::Test
   end
 
   def test_icon_tag_renders_success_icon_for_completed_state
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{% icon %}", environment: @environment)
     result = liquid_template.render("template" => drop, "state" => "completed")
@@ -114,8 +114,8 @@ class TestLiquidTags < Minitest::Test
   end
 
   def test_icon_tag_renders_failure_icon_for_failed_state
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{% icon %}", environment: @environment)
     result = liquid_template.render("template" => drop, "state" => "failed")
@@ -124,8 +124,8 @@ class TestLiquidTags < Minitest::Test
   end
 
   def test_icon_tag_renders_pending_icon_for_running_state
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{% icon %}", environment: @environment)
     result = liquid_template.render("template" => drop, "state" => "running")
@@ -134,8 +134,8 @@ class TestLiquidTags < Minitest::Test
   end
 
   def test_icon_tag_renders_pending_icon_for_pending_state
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{% icon %}", environment: @environment)
     result = liquid_template.render("template" => drop, "state" => "pending")
@@ -144,8 +144,8 @@ class TestLiquidTags < Minitest::Test
   end
 
   def test_icon_tag_without_state_renders_pending
-    template_obj = Taski::Progress::Template::Base.new
-    drop = Taski::Progress::Layout::TemplateDrop.new(template_obj)
+    theme_obj = Taski::Progress::Theme::Base.new
+    drop = Taski::Progress::Layout::ThemeDrop.new(theme_obj)
 
     liquid_template = Liquid::Template.parse("{% icon %}", environment: @environment)
     result = liquid_template.render("template" => drop)
@@ -153,8 +153,8 @@ class TestLiquidTags < Minitest::Test
     assert_equal "○", result
   end
 
-  def test_icon_tag_uses_custom_template_icons
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+  def test_icon_tag_uses_custom_theme_icons
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def icon_success
         "🎉"
       end
@@ -164,7 +164,7 @@ class TestLiquidTags < Minitest::Test
       end
     end.new
 
-    drop = Taski::Progress::Layout::TemplateDrop.new(custom_template)
+    drop = Taski::Progress::Layout::ThemeDrop.new(custom_theme)
 
     liquid_template = Liquid::Template.parse("{% icon %}", environment: @environment)
     result = liquid_template.render("template" => drop, "state" => "completed")

--- a/test/test_theme.rb
+++ b/test/test_theme.rb
@@ -2,17 +2,17 @@
 
 require "test_helper"
 require "liquid"
-require "taski/progress/template/base"
-require "taski/progress/template/default"
-require "taski/progress/template/tree"
+require "taski/progress/theme/base"
+require "taski/progress/theme/default"
+require "taski/progress/theme/detail"
 require "taski/progress/layout/filters"
 require "taski/progress/layout/tags"
-require "taski/progress/layout/template_drop"
+require "taski/progress/layout/theme_drop"
 
-class TestTemplate < Minitest::Test
+class TestTheme < Minitest::Test
   def setup
-    @template = Taski::Progress::Template::Default.new
-    @template_drop = Taski::Progress::Layout::TemplateDrop.new(@template)
+    @theme = Taski::Progress::Theme::Default.new
+    @theme_drop = Taski::Progress::Layout::ThemeDrop.new(@theme)
     @environment = Liquid::Environment.build do |env|
       env.register_filter(Taski::Progress::Layout::ColorFilter)
       env.register_tag("spinner", Taski::Progress::Layout::SpinnerTag)
@@ -23,49 +23,49 @@ class TestTemplate < Minitest::Test
   # === Task lifecycle templates ===
 
   def test_task_start_returns_liquid_template_string
-    result = @template.task_start
+    result = @theme.task_start
     assert_includes result, "{{ task.name | short_name }}"
   end
 
   def test_task_start_renders_with_task_name
-    template_string = @template.task_start
+    template_string = @theme.task_start
     rendered = render_template(template_string, "task_name" => "MyTask")
     assert_includes rendered, "MyTask"
     assert_includes rendered, "[START]"
   end
 
   def test_task_success_returns_liquid_template_string
-    result = @template.task_success
+    result = @theme.task_success
     assert_includes result, "{{ task.name | short_name }}"
   end
 
   def test_task_success_renders_without_duration
-    template_string = @template.task_success
+    template_string = @theme.task_success
     rendered = render_template(template_string, "task_name" => "MyTask", "duration" => nil)
     assert_includes rendered, "[DONE] MyTask"
     refute_includes rendered, "()"
   end
 
   def test_task_success_renders_with_duration
-    template_string = @template.task_success
+    template_string = @theme.task_success
     rendered = render_template(template_string, "task_name" => "MyTask", "task_duration" => 123)
     assert_includes rendered, "[DONE] MyTask (123ms)"
   end
 
   def test_task_fail_returns_liquid_template_string
-    result = @template.task_fail
+    result = @theme.task_fail
     assert_includes result, "{{ task.name | short_name }}"
   end
 
   def test_task_fail_renders_without_error
-    template_string = @template.task_fail
+    template_string = @theme.task_fail
     rendered = render_template(template_string, "task_name" => "MyTask", "task_error_message" => nil)
     assert_includes rendered, "[FAIL] MyTask"
     refute_includes rendered, ":"
   end
 
   def test_task_fail_renders_with_error
-    template_string = @template.task_fail
+    template_string = @theme.task_fail
     rendered = render_template(template_string, "task_name" => "MyTask", "task_error_message" => "Something went wrong")
     assert_includes rendered, "[FAIL] MyTask: Something went wrong"
   end
@@ -73,19 +73,19 @@ class TestTemplate < Minitest::Test
   # === Clean lifecycle templates ===
 
   def test_clean_start_returns_liquid_template_string
-    result = @template.clean_start
+    result = @theme.clean_start
     assert_includes result, "{{ task.name | short_name }}"
     assert_includes result, "[CLEAN]"
   end
 
   def test_clean_success_renders_with_duration
-    template_string = @template.clean_success
+    template_string = @theme.clean_success
     rendered = render_template(template_string, "task_name" => "MyTask", "task_duration" => 50)
     assert_includes rendered, "[CLEAN DONE] MyTask (50ms)"
   end
 
   def test_clean_fail_renders_with_error
-    template_string = @template.clean_fail
+    template_string = @theme.clean_fail
     rendered = render_template(template_string, "task_name" => "MyTask", "task_error_message" => "Cleanup failed")
     assert_includes rendered, "[CLEAN FAIL] MyTask: Cleanup failed"
   end
@@ -93,19 +93,19 @@ class TestTemplate < Minitest::Test
   # === Group lifecycle templates ===
 
   def test_group_start_returns_liquid_template_string
-    result = @template.group_start
+    result = @theme.group_start
     assert_includes result, "{{ task.name | short_name }}"
     assert_includes result, "{{ task.group_name }}"
   end
 
   def test_group_start_renders_correctly
-    template_string = @template.group_start
+    template_string = @theme.group_start
     rendered = render_template(template_string, "task_name" => "MyTask", "group_name" => "build")
     assert_includes rendered, "[GROUP] MyTask#build"
   end
 
   def test_group_success_renders_with_duration
-    template_string = @template.group_success
+    template_string = @theme.group_success
     rendered = render_template(template_string,
       "task_name" => "MyTask",
       "group_name" => "build",
@@ -114,7 +114,7 @@ class TestTemplate < Minitest::Test
   end
 
   def test_group_fail_renders_with_error
-    template_string = @template.group_fail
+    template_string = @theme.group_fail
     rendered = render_template(template_string,
       "task_name" => "MyTask",
       "group_name" => "build",
@@ -125,19 +125,19 @@ class TestTemplate < Minitest::Test
   # === Execution lifecycle templates ===
 
   def test_execution_start_returns_liquid_template_string
-    result = @template.execution_start
+    result = @theme.execution_start
     assert_includes result, "{{ execution.root_task_name | short_name }}"
     assert_includes result, "[TASKI]"
   end
 
   def test_execution_start_renders_correctly
-    template_string = @template.execution_start
+    template_string = @theme.execution_start
     rendered = render_template(template_string, "root_task_name" => "BuildTask")
     assert_includes rendered, "[TASKI] Starting BuildTask"
   end
 
   def test_execution_complete_renders_with_stats
-    template_string = @template.execution_complete
+    template_string = @theme.execution_complete
     rendered = render_template(template_string,
       "completed_count" => 5,
       "total_count" => 5,
@@ -146,7 +146,7 @@ class TestTemplate < Minitest::Test
   end
 
   def test_execution_fail_renders_with_stats
-    template_string = @template.execution_fail
+    template_string = @theme.execution_fail
     rendered = render_template(template_string,
       "failed_count" => 2,
       "total_count" => 5,
@@ -154,10 +154,10 @@ class TestTemplate < Minitest::Test
     assert_includes rendered, "[TASKI] Failed: 2/5 tasks (1.2s)"
   end
 
-  # === Template::Base as abstract base class ===
+  # === Theme::Base as abstract base class ===
 
   def test_base_provides_default_implementations
-    base = Taski::Progress::Template::Base.new
+    base = Taski::Progress::Theme::Base.new
     assert_kind_of String, base.task_start
     assert_kind_of String, base.task_success
     assert_kind_of String, base.task_fail
@@ -166,93 +166,93 @@ class TestTemplate < Minitest::Test
   # === Spinner configuration ===
 
   def test_spinner_frames_returns_array
-    result = @template.spinner_frames
+    result = @theme.spinner_frames
     assert_kind_of Array, result
   end
 
   def test_spinner_frames_returns_non_empty_array
-    result = @template.spinner_frames
+    result = @theme.spinner_frames
     refute_empty result
   end
 
   def test_spinner_frames_contains_braille_characters
-    result = @template.spinner_frames
+    result = @theme.spinner_frames
     assert_equal %w[⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏], result
   end
 
   def test_render_interval_returns_numeric
-    result = @template.render_interval
+    result = @theme.render_interval
     assert_kind_of Numeric, result
   end
 
   def test_render_interval_default_is_0_1
-    result = @template.render_interval
+    result = @theme.render_interval
     assert_in_delta 0.1, result, 0.001
   end
 
   # === Icon configuration ===
 
   def test_icon_success_returns_string
-    result = @template.icon_success
+    result = @theme.icon_success
     assert_kind_of String, result
   end
 
   def test_icon_success_default_is_checkmark
-    result = @template.icon_success
+    result = @theme.icon_success
     assert_equal "✓", result
   end
 
   def test_icon_failure_returns_string
-    result = @template.icon_failure
+    result = @theme.icon_failure
     assert_kind_of String, result
   end
 
   def test_icon_failure_default_is_x
-    result = @template.icon_failure
+    result = @theme.icon_failure
     assert_equal "✗", result
   end
 
   def test_icon_pending_returns_string
-    result = @template.icon_pending
+    result = @theme.icon_pending
     assert_kind_of String, result
   end
 
   def test_icon_pending_default_is_circle
-    result = @template.icon_pending
+    result = @theme.icon_pending
     assert_equal "○", result
   end
 
   # === Color configuration (ANSI codes) ===
 
   def test_color_green_returns_ansi_code
-    result = @template.color_green
+    result = @theme.color_green
     assert_equal "\e[32m", result
   end
 
   def test_color_red_returns_ansi_code
-    result = @template.color_red
+    result = @theme.color_red
     assert_equal "\e[31m", result
   end
 
   def test_color_yellow_returns_ansi_code
-    result = @template.color_yellow
+    result = @theme.color_yellow
     assert_equal "\e[33m", result
   end
 
   def test_color_reset_returns_ansi_code
-    result = @template.color_reset
+    result = @theme.color_reset
     assert_equal "\e[0m", result
   end
 
   # === Task pending template ===
 
   def test_task_pending_returns_liquid_template_string
-    result = @template.task_pending
+    result = @theme.task_pending
     assert_includes result, "{{ task.name | short_name }}"
   end
 
   def test_task_pending_renders_correctly
-    template_string = @template.task_pending
+    template_string = @theme.task_pending
     rendered = render_template(template_string, "task_name" => "MyTask")
     assert_includes rendered, "[PENDING]"
     assert_includes rendered, "MyTask"
@@ -261,13 +261,13 @@ class TestTemplate < Minitest::Test
   # === Execution running template ===
 
   def test_execution_running_returns_liquid_template_string
-    result = @template.execution_running
+    result = @theme.execution_running
     assert_includes result, "execution.done_count"
     assert_includes result, "execution.total_count"
   end
 
   def test_execution_running_renders_correctly
-    template_string = @template.execution_running
+    template_string = @theme.execution_running
     rendered = render_template(template_string,
       "done_count" => 3,
       "total_count" => 5)
@@ -297,7 +297,7 @@ class TestTemplate < Minitest::Test
       task_names: variables["task_names"]
     )
     context_vars = {
-      "template" => @template_drop,
+      "template" => @theme_drop,
       "task" => task_drop,
       "execution" => execution_drop,
       "state" => variables["state"],
@@ -307,10 +307,10 @@ class TestTemplate < Minitest::Test
   end
 end
 
-class TestTemplateTree < Minitest::Test
+class TestThemeDetail < Minitest::Test
   def setup
-    @template = Taski::Progress::Template::Tree.new
-    @template_drop = Taski::Progress::Layout::TemplateDrop.new(@template)
+    @theme = Taski::Progress::Theme::Detail.new
+    @theme_drop = Taski::Progress::Layout::ThemeDrop.new(@theme)
     @environment = Liquid::Environment.build do |env|
       env.register_filter(Taski::Progress::Layout::ColorFilter)
       env.register_tag("spinner", Taski::Progress::Layout::SpinnerTag)
@@ -321,7 +321,7 @@ class TestTemplateTree < Minitest::Test
   # === Task pending with icon ===
 
   def test_task_pending_renders_with_icon
-    template_string = @template.task_pending
+    template_string = @theme.task_pending
     rendered = render_template(template_string, "task_name" => "MyTask", "state" => "pending")
     assert_includes rendered, "○"
     assert_includes rendered, "MyTask"
@@ -330,7 +330,7 @@ class TestTemplateTree < Minitest::Test
   # === Task start with spinner ===
 
   def test_task_start_renders_with_spinner
-    template_string = @template.task_start
+    template_string = @theme.task_start
     rendered = render_template(template_string, "task_name" => "MyTask", "spinner_index" => 0)
     assert_includes rendered, "⠋"
     assert_includes rendered, "MyTask"
@@ -339,7 +339,7 @@ class TestTemplateTree < Minitest::Test
   # === Task success with colored icon ===
 
   def test_task_success_renders_with_icon
-    template_string = @template.task_success
+    template_string = @theme.task_success
     rendered = render_template(template_string,
       "task_name" => "MyTask",
       "state" => "completed",
@@ -350,7 +350,7 @@ class TestTemplateTree < Minitest::Test
   end
 
   def test_task_success_renders_without_duration
-    template_string = @template.task_success
+    template_string = @theme.task_success
     rendered = render_template(template_string,
       "task_name" => "MyTask",
       "state" => "completed",
@@ -363,7 +363,7 @@ class TestTemplateTree < Minitest::Test
   # === Task fail with colored icon ===
 
   def test_task_fail_renders_with_icon
-    template_string = @template.task_fail
+    template_string = @theme.task_fail
     rendered = render_template(template_string,
       "task_name" => "MyTask",
       "state" => "failed",
@@ -374,7 +374,7 @@ class TestTemplateTree < Minitest::Test
   end
 
   def test_task_fail_renders_without_error
-    template_string = @template.task_fail
+    template_string = @theme.task_fail
     rendered = render_template(template_string,
       "task_name" => "MyTask",
       "state" => "failed",
@@ -407,7 +407,7 @@ class TestTemplateTree < Minitest::Test
       task_names: variables["task_names"]
     )
     context_vars = {
-      "template" => @template_drop,
+      "template" => @theme_drop,
       "task" => task_drop,
       "execution" => execution_drop,
       "state" => variables["state"],

--- a/test/test_theme_drop.rb
+++ b/test/test_theme_drop.rb
@@ -2,71 +2,71 @@
 
 require "minitest/autorun"
 require "liquid"
-require_relative "../lib/taski/progress/layout/template_drop"
-require_relative "../lib/taski/progress/template/base"
+require_relative "../lib/taski/progress/layout/theme_drop"
+require_relative "../lib/taski/progress/theme/base"
 
-class TestTemplateDrop < Minitest::Test
+class TestThemeDrop < Minitest::Test
   def setup
-    @template = Taski::Progress::Template::Base.new
-    @drop = Taski::Progress::Layout::TemplateDrop.new(@template)
+    @theme = Taski::Progress::Theme::Base.new
+    @drop = Taski::Progress::Layout::ThemeDrop.new(@theme)
   end
 
-  def test_template_drop_inherits_from_liquid_drop
-    assert Taski::Progress::Layout::TemplateDrop < Liquid::Drop
+  def test_theme_drop_inherits_from_liquid_drop
+    assert Taski::Progress::Layout::ThemeDrop < Liquid::Drop
   end
 
   def test_color_red_delegation
-    assert_equal @template.color_red, @drop.color_red
+    assert_equal @theme.color_red, @drop.color_red
     assert_equal "\e[31m", @drop.color_red
   end
 
   def test_color_green_delegation
-    assert_equal @template.color_green, @drop.color_green
+    assert_equal @theme.color_green, @drop.color_green
     assert_equal "\e[32m", @drop.color_green
   end
 
   def test_color_yellow_delegation
-    assert_equal @template.color_yellow, @drop.color_yellow
+    assert_equal @theme.color_yellow, @drop.color_yellow
     assert_equal "\e[33m", @drop.color_yellow
   end
 
   def test_color_dim_delegation
-    assert_equal @template.color_dim, @drop.color_dim
+    assert_equal @theme.color_dim, @drop.color_dim
     assert_equal "\e[2m", @drop.color_dim
   end
 
   def test_color_reset_delegation
-    assert_equal @template.color_reset, @drop.color_reset
+    assert_equal @theme.color_reset, @drop.color_reset
     assert_equal "\e[0m", @drop.color_reset
   end
 
   def test_spinner_frames_delegation
-    assert_equal @template.spinner_frames, @drop.spinner_frames
+    assert_equal @theme.spinner_frames, @drop.spinner_frames
     assert_equal %w[⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏], @drop.spinner_frames
   end
 
   def test_render_interval_delegation
-    assert_equal @template.render_interval, @drop.render_interval
+    assert_equal @theme.render_interval, @drop.render_interval
     assert_equal 0.1, @drop.render_interval
   end
 
   def test_icon_success_delegation
-    assert_equal @template.icon_success, @drop.icon_success
+    assert_equal @theme.icon_success, @drop.icon_success
     assert_equal "✓", @drop.icon_success
   end
 
   def test_icon_failure_delegation
-    assert_equal @template.icon_failure, @drop.icon_failure
+    assert_equal @theme.icon_failure, @drop.icon_failure
     assert_equal "✗", @drop.icon_failure
   end
 
   def test_icon_pending_delegation
-    assert_equal @template.icon_pending, @drop.icon_pending
+    assert_equal @theme.icon_pending, @drop.icon_pending
     assert_equal "○", @drop.icon_pending
   end
 
-  def test_drop_works_with_custom_template
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+  def test_drop_works_with_custom_theme
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def color_red
         "\e[91m"  # bright red
       end
@@ -80,7 +80,7 @@ class TestTemplateDrop < Minitest::Test
       end
     end.new
 
-    custom_drop = Taski::Progress::Layout::TemplateDrop.new(custom_template)
+    custom_drop = Taski::Progress::Layout::ThemeDrop.new(custom_theme)
 
     assert_equal "\e[91m", custom_drop.color_red
     assert_equal %w[| / - \\], custom_drop.spinner_frames
@@ -113,18 +113,18 @@ class TestTemplateDrop < Minitest::Test
   end
 
   def test_format_count_delegation
-    assert_equal @template.format_count(5), @drop.format_count(5)
+    assert_equal @theme.format_count(5), @drop.format_count(5)
     assert_equal "5", @drop.format_count(5)
   end
 
   def test_format_duration_delegation
-    assert_equal @template.format_duration(500), @drop.format_duration(500)
+    assert_equal @theme.format_duration(500), @drop.format_duration(500)
     assert_equal "500ms", @drop.format_duration(500)
     assert_equal "1.5s", @drop.format_duration(1500)
   end
 
-  def test_format_methods_with_custom_template
-    custom_template = Class.new(Taski::Progress::Template::Base) do
+  def test_format_methods_with_custom_theme
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
       def format_count(count)
         "#{count}件"
       end
@@ -134,7 +134,7 @@ class TestTemplateDrop < Minitest::Test
       end
     end.new
 
-    custom_drop = Taski::Progress::Layout::TemplateDrop.new(custom_template)
+    custom_drop = Taski::Progress::Layout::ThemeDrop.new(custom_theme)
 
     assert_equal "3件", custom_drop.format_count(3)
     assert_equal "100ミリ秒", custom_drop.format_duration(100)


### PR DESCRIPTION
## Summary

- Rename `Taski::Progress::Template` module to `Taski::Progress::Theme` for clearer semantics
- Rename `Layout::Plain` to `Layout::Log` to better reflect its purpose (simple logging output)
- Rename `Template::Simple` to `Theme::Compact` and `Template::Tree` to `Theme::Detail` for consistency

## Motivation

The term "Template" was confusing because it could be conflated with Liquid templates used internally. "Theme" better describes the role of these classes: defining visual styles and formatting for progress output.

The layout rename from `Plain` to `Log` clarifies that this layout produces simple log-style output without spinners or progress indicators.

## Changes

| Before | After |
|--------|-------|
| `Taski::Progress::Template::*` | `Taski::Progress::Theme::*` |
| `Template::Simple` | `Theme::Compact` |
| `Template::Tree` | `Theme::Detail` |
| `Layout::Plain` | `Layout::Log` |
| `TemplateDrop` | `ThemeDrop` |

## Test plan

- [x] All existing tests pass (508 runs, 1200 assertions)
- [x] Standard linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated layout initialization to use `theme:` parameter instead of `template:`
  * Reorganized progress customization APIs under Theme namespace
  * Renamed TemplateDrop to ThemeDrop
  * Updated layout class names and default configurations for improved organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->