### PR TITLE
chore(deps): Bump json to 2.19.3 to fix CVE-2026-33210

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.18.1)
+    json (2.19.3)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     liquid (5.12.0)


### PR DESCRIPTION
## Summary

- The `bundler-audit` CI job was failing because `json 2.18.1` is affected by [CVE-2026-33210](https://github.com/ruby/json/security/advisories/GHSA-3m6g-2423-7cp3) (GHSA-3m6g-2423-7cp3). Bump `json` in `Gemfile.lock` from `2.18.1` to `2.19.3`.
- `json` is a transitive dependency pulled in via `activesupport` / `rubocop` / `steep`, so no changes to `Gemfile` or `taski.gemspec` are needed — this is a lockfile-only, minimal diff.

## Vulnerability detail

- **CVE**: CVE-2026-33210
- **GHSA**: GHSA-3m6g-2423-7cp3
- **Impact**: Format string injection when `JSON.parse` is called on user-supplied input with the `allow_duplicate_key: false` parsing option, which can lead to denial of service or information disclosure. The option is not the default, so projects that never opt in are not impacted.
- **Fixed in**: `~> 2.15.2.1`, `~> 2.17.1.2`, `>= 2.19.2`

## Test plan

- [x] Ran `bundle-audit check --verbose` locally and confirmed `No vulnerabilities found`
- [ ] Confirm the `bundler-audit` CI job turns green
- [ ] Confirm the existing `test` / `lint` / `build` jobs remain green