### PR TITLE
Fix executor deadlocks and hangs (abort / static-analysis / fan-in)

### DIFF
--- a/lib/taski/execution/fiber_protocol.rb
+++ b/lib/taski/execution/fiber_protocol.rb
@@ -17,6 +17,11 @@ module Taski
       CleanCompleted = Data.define(:task_class, :wrapper)
       CleanFailed = Data.define(:task_class, :wrapper, :error)
 
+      # === handle_dependency outcome (worker pool internal) ===
+      # Tells drive_fiber_loop how to proceed after resolving a NeedDep.
+      ResumeWith = Data.define(:value) # resume the parent fiber with this value
+      Parked = Data.define # parent fiber parked (or a nested dep is being driven)
+
       # === Worker thread commands (pool -> worker thread) ===
       Execute = Data.define(:task_class, :wrapper)
       ExecuteClean = Data.define(:task_class, :wrapper)

--- a/lib/taski/execution/worker_pool.rb
+++ b/lib/taski/execution/worker_pool.rb
@@ -103,7 +103,7 @@ module Taski
       # Drive a new Fiber for a task. The caller MUST have already called
       # wrapper.mark_running before enqueueing — drive_fiber never calls it.
       def drive_fiber(task_class, wrapper, queue)
-        return if @registry.abort_requested?
+        return abort_unstarted_task(task_class, wrapper) if @registry.abort_requested?
 
         analysis = Taski::StaticAnalysis::StartDepAnalyzer.analyze(task_class)
         fiber = Fiber.new do
@@ -124,6 +124,14 @@ module Taski
 
         start_output_capture(task_class)
         drive_fiber_loop(fiber, task_class, wrapper, queue)
+      rescue => e
+        # An exception escaping the pre-fiber setup (analysis, fiber creation,
+        # notifications, capture) would otherwise propagate out of worker_loop
+        # and kill this worker thread, leaving tasks routed to its queue stuck
+        # forever. Route it to fail_task so the task fails cleanly and the
+        # worker keeps serving. (drive_fiber_loop has its own rescue, so this
+        # only catches setup-phase errors and never double-fails.)
+        fail_task(task_class, wrapper, e)
       end
 
       # Drive a Fiber forward by resuming it with resume_value.
@@ -137,10 +145,13 @@ module Taski
           in FiberProtocol::StartDep => start_dep
             handle_start_dep(start_dep.task_class)
             result = fiber.resume
-            next
           in FiberProtocol::NeedDep => need_dep
-            handle_dependency(need_dep.task_class, need_dep.method, fiber, task_class, wrapper, queue)
-            return # Fiber is either continuing or parked
+            action, value = handle_dependency(need_dep.task_class, need_dep.method, fiber, task_class, wrapper, queue)
+            return if action == :parked # fiber parked (or nested dep driven); resumed later via its queue
+            # Dependency was already resolved: continue iteratively rather than
+            # recursing, so a task reading many completed deps cannot overflow
+            # the worker stack.
+            result = fiber.resume(value)
           else
             break # task.run returned a non-protocol value (normal completion)
           end
@@ -151,21 +162,29 @@ module Taski
         fail_task(task_class, wrapper, e)
       end
 
+      # Resolve a dependency for a fiber that yielded NeedDep. Returns a tuple
+      # the driver loop acts on:
+      #   [:resume, value] → resolved; resume the fiber with value iteratively
+      #   [:parked]        → fiber parked (or a nested dep is being driven);
+      #                      the driver loop must stop and let a later queue
+      #                      event resume the fiber.
       def handle_dependency(dep_class, method, fiber, task_class, wrapper, queue)
         dep_wrapper = @registry.create_wrapper(dep_class, execution_facade: @execution_facade)
         status = dep_wrapper.request_value(method, queue, fiber)
 
         case status[0]
         when :completed
-          drive_fiber_loop(fiber, task_class, wrapper, queue, status[1])
+          [:resume, status[1]]
         when :failed
-          drive_fiber_loop(fiber, task_class, wrapper, queue, FiberProtocol::DepError.new(status[1]))
+          [:resume, FiberProtocol::DepError.new(status[1])]
         when :wait
           store_fiber_context(fiber, task_class, wrapper)
+          [:parked]
         when :start
           store_fiber_context(fiber, task_class, wrapper)
           # dep_wrapper is already RUNNING (set atomically by request_value)
           drive_fiber(dep_class, dep_wrapper, queue)
+          [:parked]
         end
       end
 
@@ -240,9 +259,20 @@ module Taski
         teardown_thread_locals
       end
 
+      # A task that was scheduled (marked running) but never started because
+      # abort was requested first. Its Fiber never ran, so no thread-locals or
+      # output capture were set up. We must still mark it failed (releasing any
+      # fibers parked on it) and push a terminal event so the Executor's main
+      # loop does not block forever waiting on a completion that never arrives.
+      def abort_unstarted_task(task_class, wrapper)
+        error = Taski::TaskAbortException.new("Execution aborted before #{task_class.name} started")
+        wrapper.mark_failed(error)
+        @completion_queue.push(FiberProtocol::TaskFailed.new(task_class, wrapper, error))
+      end
+
       # Execute a clean task directly (no Fiber needed).
       def execute_clean_task(task_class, wrapper)
-        return if @registry.abort_requested?
+        return abort_unstarted_clean_task(task_class, wrapper) if @registry.abort_requested?
 
         setup_clean_thread_locals
         start_output_capture(task_class)
@@ -264,6 +294,15 @@ module Taski
       ensure
         stop_output_capture
         teardown_thread_locals
+      end
+
+      # Clean task dropped because abort was requested before its worker
+      # dequeued it. Push a terminal clean event so run_clean_main_loop does
+      # not block forever on completion_queue.pop.
+      def abort_unstarted_clean_task(task_class, wrapper)
+        error = Taski::TaskAbortException.new("Execution aborted before #{task_class.name} clean started")
+        wrapper.mark_clean_failed(error)
+        @completion_queue.push(FiberProtocol::CleanFailed.new(task_class, wrapper, error))
       end
 
       # Set up context for clean execution (no Fiber flag).

--- a/lib/taski/execution/worker_pool.rb
+++ b/lib/taski/execution/worker_pool.rb
@@ -146,12 +146,15 @@ module Taski
             handle_start_dep(start_dep.task_class)
             result = fiber.resume
           in FiberProtocol::NeedDep => need_dep
-            action, value = handle_dependency(need_dep.task_class, need_dep.method, fiber, task_class, wrapper, queue)
-            return if action == :parked # fiber parked (or nested dep driven); resumed later via its queue
-            # Dependency was already resolved: continue iteratively rather than
-            # recursing, so a task reading many completed deps cannot overflow
-            # the worker stack.
-            result = fiber.resume(value)
+            case handle_dependency(need_dep.task_class, need_dep.method, fiber, task_class, wrapper, queue)
+            in FiberProtocol::Parked
+              return # fiber parked (or nested dep driven); resumed later via its queue
+            in FiberProtocol::ResumeWith(value:)
+              # Dependency was already resolved: continue iteratively rather than
+              # recursing, so a task reading many completed deps cannot overflow
+              # the worker stack.
+              result = fiber.resume(value)
+            end
           else
             break # task.run returned a non-protocol value (normal completion)
           end
@@ -162,29 +165,29 @@ module Taski
         fail_task(task_class, wrapper, e)
       end
 
-      # Resolve a dependency for a fiber that yielded NeedDep. Returns a tuple
+      # Resolve a dependency for a fiber that yielded NeedDep. Returns a value
       # the driver loop acts on:
-      #   [:resume, value] → resolved; resume the fiber with value iteratively
-      #   [:parked]        → fiber parked (or a nested dep is being driven);
-      #                      the driver loop must stop and let a later queue
-      #                      event resume the fiber.
+      #   FiberProtocol::ResumeWith(value) → resolved; resume the fiber with value
+      #   FiberProtocol::Parked            → fiber parked (or a nested dep is being
+      #                                      driven); the driver loop must stop and
+      #                                      let a later queue event resume the fiber.
       def handle_dependency(dep_class, method, fiber, task_class, wrapper, queue)
         dep_wrapper = @registry.create_wrapper(dep_class, execution_facade: @execution_facade)
         status = dep_wrapper.request_value(method, queue, fiber)
 
         case status[0]
         when :completed
-          [:resume, status[1]]
+          FiberProtocol::ResumeWith.new(status[1])
         when :failed
-          [:resume, FiberProtocol::DepError.new(status[1])]
+          FiberProtocol::ResumeWith.new(FiberProtocol::DepError.new(status[1]))
         when :wait
           store_fiber_context(fiber, task_class, wrapper)
-          [:parked]
+          FiberProtocol::Parked.new
         when :start
           store_fiber_context(fiber, task_class, wrapper)
           # dep_wrapper is already RUNNING (set atomically by request_value)
           drive_fiber(dep_class, dep_wrapper, queue)
-          [:parked]
+          FiberProtocol::Parked.new
         end
       end
 

--- a/lib/taski/static_analysis/dependency_graph.rb
+++ b/lib/taski/static_analysis/dependency_graph.rb
@@ -52,9 +52,13 @@ module Taski
       end
 
       # Get task classes involved in cycles
-      # @return [Array<Array<Class>>] Only components with size > 1 (cycles)
+      # @return [Array<Array<Class>>] Components that form a cycle: either a
+      #   strongly connected component of size > 1, or a single task that
+      #   depends on itself (a self-loop SCC of size 1).
       def cyclic_components
-        strongly_connected_components.select { |component| component.size > 1 }
+        strongly_connected_components.select do |component|
+          component.size > 1 || self_dependent?(component.first)
+        end
       end
 
       # Get all task classes in the graph
@@ -81,6 +85,11 @@ module Taski
       end
 
       private
+
+      # Check whether a task class directly depends on itself (self-loop).
+      def self_dependent?(task_class)
+        dependencies_for(task_class).include?(task_class)
+      end
 
       # Recursively collect all dependencies starting from a task class
       def collect_dependencies(task_class)

--- a/lib/taski/static_analysis/start_dep_analyzer.rb
+++ b/lib/taski/static_analysis/start_dep_analyzer.rb
@@ -83,7 +83,11 @@ module Taski
         start_deps = all_dep_classes - unsafe_classes
         sync_deps = unsafe_classes
         AnalysisResult.new(start_deps: start_deps, sync_deps: sync_deps)
-      rescue NameError
+      rescue
+        # Prestart analysis is a pure performance optimization. If anything goes
+        # wrong (missing/unreadable source file, unexpected AST shape, constant
+        # resolution failure, ...) degrade to no prestart — tasks still execute
+        # correctly via lazy Fiber pull. This must never crash a worker thread.
         EMPTY_RESULT
       end
 

--- a/lib/taski/test_helper.rb
+++ b/lib/taski/test_helper.rb
@@ -65,7 +65,10 @@ module Taski
     # @api private
     module WorkerPoolExtension
       def drive_fiber(task_class, wrapper, queue)
-        return if @registry.abort_requested?
+        # Delegate the abort case to the real drive_fiber so the dropped task
+        # still emits a terminal event (otherwise a parent parked on it
+        # deadlocks). Abort takes precedence over mock handling.
+        return super if @registry.abort_requested?
 
         if MockRegistry.mock_for(task_class)
           wrapper.mark_completed(nil) unless wrapper.completed?

--- a/test/fixtures/abort_tasks.rb
+++ b/test/fixtures/abort_tasks.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "taski"
+
+# Fixtures for verifying that aborting one task does not deadlock the executor
+# when a sibling task is dropped (its drive_fiber early-returns on abort).
+#
+# With workers: 1 the schedule is deterministic:
+#   1. AbortRoot prestarts Aborter (first) then Victim.
+#   2. Aborter is dequeued first, runs, and raises TaskAbortException (sets the
+#      abort flag).
+#   3. AbortRoot's run body resolves the Victim proxy in the interpolation and
+#      parks waiting on Victim.
+#   4. Victim is dequeued next; drive_fiber sees abort_requested? and drops it.
+#
+# Without a terminal event for the dropped Victim, AbortRoot is parked forever
+# and the executor's main loop blocks on completion_queue.pop (deadlock).
+module AbortFixtures
+  class Aborter < Taski::Task
+    exports :value
+
+    def run
+      raise Taski::TaskAbortException, "abort now"
+    end
+  end
+
+  class Victim < Taski::Task
+    exports :value
+
+    def run
+      @value = "victim ran"
+    end
+  end
+
+  class AbortRoot < Taski::Task
+    exports :value
+
+    def run
+      _aborter = Aborter.value # prestarted, runs first and aborts (never resolved here)
+      v = Victim.value
+      @value = v.to_s
+    end
+  end
+end

--- a/test/fixtures/circular_tasks.rb
+++ b/test/fixtures/circular_tasks.rb
@@ -21,6 +21,15 @@ class CircularTaskB < Taski::Task
   end
 end
 
+# Self-referential dependency: a task that depends on itself (cycle of size 1)
+class SelfReferentialTask < Taski::Task
+  exports :value
+
+  def run
+    @value = "self: #{SelfReferentialTask.value}"
+  end
+end
+
 # Indirect circular dependency: X -> Y -> Z -> X
 module IndirectCircular
   class TaskX < Taski::Task

--- a/test/fixtures/fan_in_tasks.rb
+++ b/test/fixtures/fan_in_tasks.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "taski"
+
+# Fixtures for verifying that resolving many already-completed dependencies in a
+# single task does not grow the worker call stack unboundedly.
+#
+# DeepFanInRoot reads Leaf.value many times inside a loop. The loop makes Leaf a
+# synchronous (NeedDep) dependency; after the first resolution every subsequent
+# read returns :completed. If each :completed read recurses into drive_fiber_loop
+# instead of iterating, the worker stack grows one frame per read and overflows
+# (SystemStackError, which is not a StandardError and so escapes the worker's
+# rescue, killing the worker thread and hanging the executor).
+module FanInFixtures
+  class Leaf < Taski::Task
+    exports :value
+
+    def run
+      @value = 1
+    end
+  end
+
+  class DeepFanInRoot < Taski::Task
+    exports :total
+
+    READS = 50_000
+
+    def run
+      sum = 0
+      READS.times { sum += Leaf.value }
+      @total = sum
+    end
+  end
+end

--- a/test/test_circular_dependency.rb
+++ b/test/test_circular_dependency.rb
@@ -29,6 +29,24 @@ class TestCircularDependency < Minitest::Test
     assert_includes error.message, "CircularTaskB"
   end
 
+  def test_detects_self_dependency_in_cyclic_components
+    require_relative "fixtures/circular_tasks"
+
+    graph = Taski::StaticAnalysis::DependencyGraph.new.build_from(SelfReferentialTask)
+
+    assert_includes graph.cyclic_components.flatten, SelfReferentialTask
+  end
+
+  def test_self_dependency_raises_circular_error_instead_of_hanging
+    require_relative "fixtures/circular_tasks"
+
+    error = assert_raises(Taski::CircularDependencyError) do
+      Timeout.timeout(5) { SelfReferentialTask.value }
+    end
+
+    assert_includes error.message, "SelfReferentialTask"
+  end
+
   def test_detects_indirect_circular_dependency
     require_relative "fixtures/circular_tasks"
 

--- a/test/test_executor.rb
+++ b/test/test_executor.rb
@@ -11,6 +11,21 @@ class TestExecutor < Minitest::Test
     Taski::Task.reset! if defined?(Taski::Task)
   end
 
+  # An unexpected exception raised in framework code BEFORE the task fiber is
+  # created (e.g. inside StartDepAnalyzer.analyze in drive_fiber) must not kill
+  # the worker thread silently. If it did, future tasks routed to that worker's
+  # queue would never run and the executor would deadlock. Instead the task
+  # should be marked failed and surfaced as an AggregateError.
+  def test_worker_survives_unexpected_framework_error
+    error = assert_raises(Taski::AggregateError) do
+      with_stubbed_start_dep_analyze(->(_task_class) { raise "boom in analysis" }) do
+        Timeout.timeout(10) { ExecutorFixtures::SingleTask.run(workers: 1) }
+      end
+    end
+
+    assert_includes error.message, "boom in analysis"
+  end
+
   def test_single_task_no_deps
     task_class = ExecutorFixtures::SingleTask
 
@@ -788,5 +803,16 @@ class TestExecutor < Minitest::Test
 
   def create_execution_facade(registry, task_class)
     Taski::Execution::ExecutionFacade.new(root_task_class: task_class)
+  end
+
+  # Temporarily replace StartDepAnalyzer.analyze (a class method) for the
+  # duration of the block. Used to simulate an unexpected framework failure.
+  def with_stubbed_start_dep_analyze(impl)
+    singleton = Taski::StaticAnalysis::StartDepAnalyzer.singleton_class
+    original = singleton.instance_method(:analyze)
+    singleton.send(:define_method, :analyze, impl)
+    yield
+  ensure
+    singleton.send(:define_method, :analyze, original)
   end
 end

--- a/test/test_fan_in_recursion.rb
+++ b/test/test_fan_in_recursion.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "fixtures/fan_in_tasks"
+
+class TestFanInRecursion < Minitest::Test
+  def setup
+    Taski::Task.reset! if defined?(Taski::Task)
+  end
+
+  # Reading a large number of already-completed dependencies must not overflow
+  # the worker stack. drive_fiber_loop must iterate over resolved dependencies
+  # rather than recursing once per resolution.
+  def test_many_completed_dependency_reads_do_not_overflow_stack
+    total = nil
+
+    Timeout.timeout(30) do
+      total = FanInFixtures::DeepFanInRoot.total(args: {})
+    end
+
+    assert_equal FanInFixtures::DeepFanInRoot::READS, total
+  end
+end

--- a/test/test_start_dep_analyzer.rb
+++ b/test/test_start_dep_analyzer.rb
@@ -64,6 +64,32 @@ class TestStartDepAnalyzer < Minitest::Test
     assert_includes result.start_deps, StartDepAnalyzerFixtures::LeafTask
   end
 
+  def test_analyze_degrades_to_empty_when_source_file_unreadable
+    require "tempfile"
+
+    file = Tempfile.new(["start_dep_missing_source", ".rb"])
+    file.write(<<~RUBY)
+      module StartDepMissingSourceFixture
+        class Task1 < Taski::Task
+          exports :value
+          def run
+            @value = "x"
+          end
+        end
+      end
+    RUBY
+    file.close
+    load file.path
+    klass = StartDepMissingSourceFixture::Task1
+
+    Taski::StaticAnalysis::StartDepAnalyzer.clear_cache!
+    File.delete(file.path) # Prism.parse_file now raises Errno::ENOENT
+
+    result = Taski::StaticAnalysis::StartDepAnalyzer.analyze(klass)
+
+    assert_equal Taski::StaticAnalysis::StartDepAnalyzer::EMPTY_RESULT, result
+  end
+
   def test_caching
     result1 = Taski::StaticAnalysis::StartDepAnalyzer.analyze(
       StartDepAnalyzerFixtures::IvarAssignment

--- a/test/test_test_helper.rb
+++ b/test/test_test_helper.rb
@@ -3,6 +3,7 @@
 require "test_helper"
 require "taski/test_helper"
 require "taski/test_helper/minitest"
+require_relative "fixtures/abort_tasks"
 
 # Fixture tasks for testing the test helper
 module TestHelperFixtures
@@ -83,6 +84,16 @@ class TestTestHelper < Minitest::Test
 
   def teardown
     Taski::TestHelper.reset_mocks!
+  end
+
+  # WorkerPoolExtension#drive_fiber (prepended when taski/test_helper loads)
+  # must handle abort the same way as the real drive_fiber: a task dropped on
+  # abort still needs a terminal event, otherwise a parent parked on it
+  # deadlocks. This guards against the extension re-introducing the bug.
+  def test_abort_does_not_deadlock_with_test_helper_extensions_loaded
+    assert_raises(Taski::TaskAbortException) do
+      Timeout.timeout(15) { AbortFixtures::AbortRoot.run(workers: 1) }
+    end
   end
 
   # === T007: Test basic mock registration and retrieval ===

--- a/test/test_user_abort.rb
+++ b/test/test_user_abort.rb
@@ -3,6 +3,7 @@
 require_relative "test_helper"
 require_relative "fixtures/error_tasks"
 require_relative "fixtures/parallel_tasks"
+require_relative "fixtures/abort_tasks"
 
 class TestUserAbort < Minitest::Test
   include TaskiTestHelper
@@ -10,6 +11,16 @@ class TestUserAbort < Minitest::Test
   def setup
     setup_taski_test
     ErrorFixtures::ExecutionTracker.clear
+  end
+
+  # When a task is dropped because abort was requested before its worker
+  # dequeued it, it must still emit a terminal completion event and release
+  # any fibers parked on it. Otherwise the parent that parked on the dropped
+  # task waits forever and the executor's main loop deadlocks.
+  def test_abort_does_not_deadlock_when_parked_on_dropped_task
+    assert_raises(Taski::TaskAbortException) do
+      Timeout.timeout(15) { AbortFixtures::AbortRoot.run(workers: 1) }
+    end
   end
 
   # Test that TaskAbortException can be raised to abort a task


### PR DESCRIPTION
## Summary

A deep audit surfaced a cluster of **deadlock / hang** bugs in the execution engine. This PR fixes them, each with a regression test that was confirmed RED before the fix and GREEN after.

All changes keep the existing public behavior; backward compatibility is not affected.

## Fixes

| Bug | Symptom | Fix |
|-----|---------|-----|
| **Abort drops the terminal event** (run + clean) | A task scheduled (marked running) but dropped because abort was requested before its worker dequeued it never emitted a completion event, so the main loop blocked forever on `completion_queue.pop`. Also stranded a parent fiber parked on it (the nested `:start` abort case). | `drive_fiber` / `execute_clean_task` now call `abort_unstarted_task` / `abort_unstarted_clean_task`, which mark the wrapper failed (releasing parked fibers) and push a terminal event. |
| **Self-dependency not detected** | A task referencing itself (`def run; @v = Self.v; end`) is a size-1 self-loop that `cyclic_components` filtered out (`size > 1`), so it deadlocked at runtime instead of raising. | `cyclic_components` now also includes a single component that depends on itself → `CircularDependencyError` up front. |
| **Analysis error kills a worker** | `Prism.parse_file` raising `Errno` (moved/unreadable source) escaped `StartDepAnalyzer.analyze` (which only rescued `NameError`), propagated out of `worker_loop`, and killed the worker thread → tasks routed to its queue hung. | `analyze` now degrades to `EMPTY_RESULT` on any error. Prestart is a pure optimization; tasks still run via lazy Fiber pull. |
| **Unexpected framework error kills a worker** | Any exception in `drive_fiber`'s pre-fiber setup escaped `worker_loop`. | `drive_fiber` now rescues setup-phase errors and routes them to `fail_task` (the task fails cleanly, the worker keeps serving). |
| **Deep fan-in overflows the stack** | Reading many already-completed dependencies recursed into `drive_fiber_loop` once per resolution → `SystemStackError` (not a `StandardError`, so it escaped the rescue and killed the worker). | `drive_fiber_loop` resolves completed/failed deps iteratively; `handle_dependency` returns `[:resume, value]` / `[:parked]`. |
| **Same abort bug in the test helper** | `Taski::TestHelper::WorkerPoolExtension#drive_fiber` (prepended onto `WorkerPool` when `taski/test_helper` is loaded) had the identical abort early-return, bypassing the fix. Manifested as "passes in isolation, hangs in the full suite". | The extension now delegates the abort case to the fixed `super`. |

## Tests

7 new regression tests (696 → 703 runs). Each reproduces the hang/crash (Timeout / Errno / empty cyclic set / SystemStackError) before the fix:

- `test_circular_dependency.rb` — self-dep in `cyclic_components` + raises instead of hanging
- `test_user_abort.rb` — no deadlock when parked on a dropped task
- `test_start_dep_analyzer.rb` — `analyze` degrades to `EMPTY_RESULT` on unreadable source
- `test_executor.rb` — worker survives an unexpected framework error
- `test_fan_in_recursion.rb` — 50k completed-dep reads do not overflow the stack
- `test_test_helper.rb` — no deadlock with the test-helper extensions loaded

## Verification

`bundle exec rake` (test + standard) → exit 0, **703 runs, 1666 assertions, 0 failures, 0 errors**.

## Note

Dropped-on-abort tasks are marked failed with `TaskAbortException`; `raise_if_any_failures` already re-raises an abort exception with priority, so callers still receive a clean `TaskAbortException` (not an `AggregateError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deadlocks when aborting queued or parked tasks; aborted tasks now reliably emit terminal events
  * Stopped worker-thread crashes from unexpected analysis errors by routing failures safely
  * Expanded circular-dependency detection to include self-referential cycles

* **New Features**
  * Added internal fiber control signals to improve dependency resolution and parking behavior
  * Prestart analysis now fails gracefully and falls back to a safe empty result when it errors

* **Tests**
  * Added regression tests and fixtures for abort/drop and parked-task deadlock scenarios
  * Added tests for self-referential cycles, fan-in stress reads, and analyzer degradation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->