### PR TITLE
chore(deps): bump erb to 6.0.4 to fix CVE-2026-41316

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
       reline (>= 0.3.8)
     docile (1.4.1)
     drb (2.2.3)
-    erb (6.0.1)
+    erb (6.0.4)
     ffi (1.17.4)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)


### PR DESCRIPTION
bundler-audit was failing because erb 6.0.1 (a transitive dependency)
is affected by CVE-2026-41316 (GHSA-q339-8rmv-2mhv), a High severity
deserialization guard bypass. Update to 6.0.4 per the advisory.

https://claude.ai/code/session_01MZCNb78BTxdPZswnW1arQw