### PR TITLE
ci: use latest Bundler for the debug Ruby job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
       uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         ruby-version: ${{ matrix.ruby-version }}
+        # The debug (nightly) Ruby ships an old default Bundler that crashes on
+        # `bundle install` (NameError: uninitialized constant Pathname::SEPARATOR_PAT).
+        # Use the latest Bundler there so the nightly tests can actually run.
+        bundler: ${{ matrix.ruby-version == 'debug' && 'latest' || 'default' }}
         bundler-cache: false
 
     - name: Fix gem directory permissions (Ruby 4.0+)


### PR DESCRIPTION
The nightly (debug) Ruby ships an old default Bundler (2.6.2) that crashes
during `bundle install` with:

  NameError: uninitialized constant Pathname::SEPARATOR_PAT

because recent Ruby head removed Pathname::SEPARATOR_PAT while the bundled
Bundler still references it. This made the debug matrix job fail before it
could run any tests (hidden by continue-on-error).

Install the latest Bundler only for the debug job so the nightly Ruby tests
actually run; other versions keep their default Bundler.

https://claude.ai/code/session_017uTPpVNhMb3hoBKM9LSFgV