### PR TITLE
Harden resource/display lifecycle and unify progress layouts behind a .build factory

### DIFF
--- a/lib/taski/execution/execution_facade.rb
+++ b/lib/taski/execution/execution_facade.rb
@@ -80,6 +80,10 @@ module Taski
           @original_stderr = nil
         end
         capture&.stop_polling
+        # Close every pipe so its file descriptors are released deterministically
+        # rather than leaking until the router is garbage-collected. Done after
+        # stop_polling so the poll thread is no longer reading the pipes.
+        capture&.close_all
       end
 
       def output_capture

--- a/lib/taski/execution/executor.rb
+++ b/lib/taski/execution/executor.rb
@@ -45,15 +45,19 @@ module Taski
             completion_queue: @completion_queue
           )
 
-          @worker_pool.start
+          begin
+            @worker_pool.start
 
-          enqueue_root_if_needed(root_task_class)
+            enqueue_root_if_needed(root_task_class)
 
-          run_main_loop(root_task_class)
+            run_main_loop(root_task_class)
 
-          @worker_pool.shutdown
-
-          notify_skipped_tasks
+            notify_skipped_tasks
+          ensure
+            # Always shut the pool down — otherwise a raise in the main loop
+            # leaves worker threads blocked on queue.pop forever.
+            @worker_pool.shutdown
+          end
         end
 
         log_execution_completed(root_task_class, start_time)
@@ -72,10 +76,15 @@ module Taski
             worker_count: @effective_worker_count,
             completion_queue: @completion_queue
           )
-          @worker_pool.start
-          enqueue_ready_clean_tasks
-          run_clean_main_loop
-          @worker_pool.shutdown
+          begin
+            @worker_pool.start
+            enqueue_ready_clean_tasks
+            run_clean_main_loop
+          ensure
+            # Always shut the pool down so a raise in the clean loop cannot
+            # leak worker threads.
+            @worker_pool.shutdown
+          end
         end
 
         raise_if_any_clean_failures

--- a/lib/taski/progress/config.rb
+++ b/lib/taski/progress/config.rb
@@ -64,19 +64,19 @@ module Taski
         args[:theme] = @theme.new if @theme
         args[:output] = @output if @output
 
-        if layout_ref.respond_to?(:for)
-          layout_ref.for(**args)
-        else
-          layout_ref.new(**args)
-        end
+        # Every layout exposes the same factory: .build(output:, theme:) returning
+        # a Layout::Base instance. The layout itself decides which concrete class
+        # to build (Simple/Log return their single class; Tree picks Live/Event).
+        layout_ref.build(**args)
       end
 
       def validate_layout!(klass)
-        # Accept a Class that inherits from Base, or a Module with .for factory
-        valid = (klass.is_a?(Class) && klass <= Layout::Base) ||
-          (klass.is_a?(Module) && klass.respond_to?(:for))
-        unless valid
-          raise ArgumentError, "layout must be a Layout::Base subclass or a module with .for, got #{klass.inspect}"
+        # A layout is anything that responds to .build. That admits the public
+        # layouts (Simple, Log, Tree) and custom ones, while rejecting instances,
+        # non-layout classes, and the internal Tree::Live / Tree::Event variants
+        # (which have no .build, so they can't be forced as a layout directly).
+        unless klass.respond_to?(:build)
+          raise ArgumentError, "layout must respond to .build (e.g. Simple, Log, Tree, or a custom layout), got #{klass.inspect}"
         end
       end
 

--- a/lib/taski/progress/layout/base.rb
+++ b/lib/taski/progress/layout/base.rb
@@ -174,6 +174,13 @@ module Taski
           template = Liquid::Template.parse(template_string, environment: @liquid_environment)
           template.assigns["state"] = state
           template.render(context_vars)
+        rescue Liquid::Error => e
+          # A malformed/buggy theme template must not raise out of here: in the
+          # live/event render paths this runs on a background thread and an
+          # exception would silently kill it, freezing the display. Degrade to an
+          # empty string and surface the error to the logger instead.
+          Taski::Logging.warn(Taski::Logging::Events::OBSERVER_ERROR, error_message: "template render failed: #{e.message}")
+          ""
         end
 
         # Start the spinner animation timer.
@@ -190,7 +197,8 @@ module Taski
               break unless running
               sleep @theme.spinner_interval
               @monitor.synchronize do
-                @spinner_index = (@spinner_index + 1) % @theme.spinner_frames.size
+                frame_count = @theme.spinner_frames.size
+                @spinner_index = (@spinner_index + 1) % frame_count unless frame_count.zero?
               end
             end
           end

--- a/lib/taski/progress/layout/base.rb
+++ b/lib/taski/progress/layout/base.rb
@@ -173,13 +173,25 @@ module Taski
           context_vars = build_context_vars(task:, execution:, **variables)
           template = Liquid::Template.parse(template_string, environment: @liquid_environment)
           template.assigns["state"] = state
-          template.render(context_vars)
+          output = template.render(context_vars)
+          # Liquid renders in lax mode: a runtime error (bad filter/tag/drop, e.g.
+          # divide-by-zero) does NOT raise — it is recorded in template.errors and
+          # inlined into the output as literal "Liquid error: ..." text. Degrade to
+          # "" and surface it rather than leaking that into the display.
+          return warn_and_blank(template.errors.first) if template.errors.any?
+
+          output
         rescue Liquid::Error => e
           # A malformed/buggy theme template must not raise out of here: in the
           # live/event render paths this runs on a background thread and an
-          # exception would silently kill it, freezing the display. Degrade to an
-          # empty string and surface the error to the logger instead.
-          Taski::Logging.warn(Taski::Logging::Events::OBSERVER_ERROR, error_message: "template render failed: #{e.message}")
+          # exception (here a parse-time SyntaxError) would silently kill it,
+          # freezing the display. Degrade to "" and surface the error.
+          warn_and_blank(e)
+        end
+
+        # Log a template failure and return the empty-string fallback.
+        def warn_and_blank(error)
+          Taski::Logging.warn(Taski::Logging::Events::OBSERVER_ERROR, error_message: "template render failed: #{error.message}")
           ""
         end
 

--- a/lib/taski/progress/layout/log.rb
+++ b/lib/taski/progress/layout/log.rb
@@ -15,11 +15,19 @@ module Taski
       #   [FAIL] TaskName: Error message
       #
       # Uses Theme::Plain by default to ensure no ANSI escape codes in output.
-      class Log < Base
-        def initialize(output: $stderr, theme: nil)
-          theme ||= Theme::Plain.new
-          super
-          @output.sync = true if @output.respond_to?(:sync=)
+      module Log
+        # Build the plain-text display (Log has a single implementation).
+        # @return [Log::Display]
+        def self.build(output: $stderr, theme: nil)
+          Display.new(output: output, theme: theme)
+        end
+
+        class Display < Base
+          def initialize(output: $stderr, theme: nil)
+            theme ||= Theme::Plain.new
+            super
+            @output.sync = true if @output.respond_to?(:sync=)
+          end
         end
       end
     end

--- a/lib/taski/progress/layout/simple.rb
+++ b/lib/taski/progress/layout/simple.rb
@@ -31,120 +31,129 @@ module Taski
       #     end
       #   end
       #
-      #   layout = Taski::Progress::Layout::Simple.new(theme: MyTheme.new)
-      class Simple < Base
-        def initialize(output: $stdout, theme: nil)
-          theme ||= Theme::Compact.new
-          super
+      #   Taski.progress.layout = Taski::Progress::Layout::Simple
+      #   Taski.progress.theme = MyTheme
+      module Simple
+        # Build the single-line display (Simple has a single implementation).
+        # @return [Simple::Display]
+        def self.build(output: $stdout, theme: nil)
+          Display.new(output: output, theme: theme)
         end
 
-        protected
+        class Display < Base
+          def initialize(output: $stdout, theme: nil)
+            theme ||= Theme::Compact.new
+            super
+          end
 
-        # === Template method overrides ===
+          protected
 
-        def handle_ready
-          graph = context&.dependency_graph
-          return unless graph
+          # === Template method overrides ===
 
-          graph.all_tasks.each { |tc| register_task(tc) }
-        end
+          def handle_ready
+            graph = context&.dependency_graph
+            return unless graph
 
-        # Simple layout uses periodic status line updates instead of per-event output
-        def handle_task_update(_task_class, _current_state, _phase)
-          # No per-event output; status line is updated by render_live
-        end
+            graph.all_tasks.each { |tc| register_task(tc) }
+          end
 
-        def handle_group_started(_task_class, _group_name, _phase)
-          # No per-event output; status line is updated by render_live
-        end
+          # Simple layout uses periodic status line updates instead of per-event output
+          def handle_task_update(_task_class, _current_state, _phase)
+            # No per-event output; status line is updated by render_live
+          end
 
-        def handle_group_completed(_task_class, _group_name, _phase, _duration)
-          # No per-event output; status line is updated by render_live
-        end
+          def handle_group_started(_task_class, _group_name, _phase)
+            # No per-event output; status line is updated by render_live
+          end
 
-        def should_activate?
-          tty?
-        end
+          def handle_group_completed(_task_class, _group_name, _phase, _duration)
+            # No per-event output; status line is updated by render_live
+          end
 
-        def handle_start
-          @output.print "\e[?25l"  # Hide cursor
-          render_loop { render_status_line }
-        end
+          def should_activate?
+            tty?
+          end
 
-        def handle_stop
-          stop_render_loop
-          @output.print "\e[?25h"  # Show cursor
-          render_final
-        end
+          def handle_start
+            @output.print "\e[?25l"  # Hide cursor
+            render_loop { render_status_line }
+          end
 
-        private
+          def handle_stop
+            stop_render_loop
+            @output.print "\e[?25h"  # Show cursor
+            render_final
+          end
 
-        def render_status_line
-          line = build_status_line
-          # Truncate line to terminal width to prevent line wrap
-          max_width = terminal_width - 1  # Leave space for cursor
-          line = line[0, max_width] if line.length > max_width
-          # Clear line and write new content
-          @output.print "\r\e[K#{line}"
-          @output.flush
-        end
+          private
 
-        def terminal_width
-          @output.winsize[1]
-        rescue
-          80 # Default fallback
-        end
-
-        def render_final
-          @monitor.synchronize do
-            line = if failed_count > 0
-              render_execution_failed(failed_count: failed_count, total_count: total_count, total_duration: total_duration, skipped_count: skipped_count)
-            else
-              render_execution_completed(done_count: done_count, total_count: total_count, total_duration: total_duration, skipped_count: skipped_count)
-            end
-
-            @output.print "\r\e[K#{line}\n"
+          def render_status_line
+            line = build_status_line
+            # Truncate line to terminal width to prevent line wrap
+            max_width = terminal_width - 1  # Leave space for cursor
+            line = line[0, max_width] if line.length > max_width
+            # Clear line and write new content
+            @output.print "\r\e[K#{line}"
             @output.flush
           end
-        end
 
-        def build_status_line
-          task_names = collect_current_task_names
-
-          primary_task = running_tasks.keys.last || cleaning_tasks.keys.last
-          task_stdout = build_task_stdout(primary_task)
-
-          render_execution_running(
-            done_count: done_count,
-            total_count: total_count,
-            task_names: task_names.empty? ? nil : task_names,
-            task_stdout: task_stdout
-          )
-        end
-
-        def collect_current_task_names
-          # Prioritize: cleaning > running > pending
-          # Reverse so most recently started tasks appear first
-          current_tasks = if cleaning_tasks.any?
-            cleaning_tasks.keys.reverse
-          elsif running_tasks.any?
-            running_tasks.keys.reverse
-          elsif pending_tasks.any?
-            pending_tasks.keys.reverse
-          else
-            []
+          def terminal_width
+            @output.winsize[1]
+          rescue
+            80 # Default fallback
           end
 
-          current_tasks.map { |t| task_class_name(t) }
-        end
+          def render_final
+            @monitor.synchronize do
+              line = if failed_count > 0
+                render_execution_failed(failed_count: failed_count, total_count: total_count, total_duration: total_duration, skipped_count: skipped_count)
+              else
+                render_execution_completed(done_count: done_count, total_count: total_count, total_duration: total_duration, skipped_count: skipped_count)
+              end
 
-        def build_task_stdout(task_class)
-          return nil unless @output_capture && task_class
+              @output.print "\r\e[K#{line}\n"
+              @output.flush
+            end
+          end
 
-          last_line = @output_capture.last_line_for(task_class)
-          return nil unless last_line && !last_line.strip.empty?
+          def build_status_line
+            task_names = collect_current_task_names
 
-          last_line.strip
+            primary_task = running_tasks.keys.last || cleaning_tasks.keys.last
+            task_stdout = build_task_stdout(primary_task)
+
+            render_execution_running(
+              done_count: done_count,
+              total_count: total_count,
+              task_names: task_names.empty? ? nil : task_names,
+              task_stdout: task_stdout
+            )
+          end
+
+          def collect_current_task_names
+            # Prioritize: cleaning > running > pending
+            # Reverse so most recently started tasks appear first
+            current_tasks = if cleaning_tasks.any?
+              cleaning_tasks.keys.reverse
+            elsif running_tasks.any?
+              running_tasks.keys.reverse
+            elsif pending_tasks.any?
+              pending_tasks.keys.reverse
+            else
+              []
+            end
+
+            current_tasks.map { |t| task_class_name(t) }
+          end
+
+          def build_task_stdout(task_class)
+            return nil unless @output_capture && task_class
+
+            last_line = @output_capture.last_line_for(task_class)
+            return nil unless last_line && !last_line.strip.empty?
+
+            last_line.strip
+          end
         end
       end
     end

--- a/lib/taski/progress/layout/tags.rb
+++ b/lib/taski/progress/layout/tags.rb
@@ -19,6 +19,8 @@ module Taski
         def render(context)
           template = context["template"]
           frames = template&.spinner_frames || DEFAULT_FRAMES
+          return "" if frames.empty? # a custom theme may return no frames; avoid divide-by-zero
+
           index = context["spinner_index"] || 0
           frames[index % frames.size]
         end

--- a/lib/taski/progress/layout/tree.rb
+++ b/lib/taski/progress/layout/tree.rb
@@ -7,29 +7,30 @@ require_relative "tree/event"
 module Taski
   module Progress
     module Layout
-      # Tree layout module for hierarchical task display.
+      # Tree layout for hierarchical task display.
       # Renders tasks in a tree structure with visual connectors.
       #
-      # Contains two implementations:
+      # Tree has two implementations and picks the right one itself, so it
+      # presents the same layout factory interface as Simple/Log — `.build` —
+      # returning a Layout::Base instance:
       # - Tree::Live  — TTY periodic-update with spinner animation
       # - Tree::Event — Non-TTY event-driven incremental output
       #
-      # Use Tree.for to automatically select the appropriate implementation.
+      # Tree::Live / Tree::Event are internal; pick the layout via the Tree kind
+      # and let it decide:
       #
-      # @example Auto-select based on output TTY
-      #   layout = Taski::Progress::Layout::Tree.for
-      #
-      # @example Explicit selection
-      #   layout = Taski::Progress::Layout::Tree::Live.new   # TTY
-      #   layout = Taski::Progress::Layout::Tree::Event.new  # non-TTY
+      # @example
+      #   Taski.progress.layout = Taski::Progress::Layout::Tree
       module Tree
-        # Factory method to create the appropriate tree layout.
-        # Returns Tree::Live for TTY outputs, Tree::Event otherwise.
+        # Build the appropriate tree layout from the given options. Tree decides
+        # which concrete class to use: Tree::Live for a TTY output, Tree::Event
+        # otherwise. Matches the layout factory interface (.build) so the progress
+        # Config can treat every layout uniformly.
         #
         # @param output [IO] Output stream (default: $stderr)
         # @param theme [Theme::Base, nil] Theme instance
         # @return [Tree::Live, Tree::Event]
-        def self.for(output: $stderr, theme: nil)
+        def self.build(output: $stderr, theme: nil)
           if output.respond_to?(:tty?) && output.tty?
             Live.new(output: output, theme: theme)
           else

--- a/lib/taski/progress/theme/base.rb
+++ b/lib/taski/progress/theme/base.rb
@@ -21,7 +21,8 @@ module Taski
       #     end
       #   end
       #
-      #   layout = Taski::Progress::Layout::Log.new(theme: MyTheme.new)
+      #   Taski.progress.layout = Taski::Progress::Layout::Log
+      #   Taski.progress.theme = MyTheme
       class Base
         # === Task lifecycle templates ===
 

--- a/lib/taski/progress/theme/compact.rb
+++ b/lib/taski/progress/theme/compact.rb
@@ -13,9 +13,8 @@ module Taski
       #   ✓ [5/5] All tasks completed (1.2s)
       #
       # @example Usage
-      #   layout = Taski::Progress::Layout::Simple.new(
-      #     theme: Taski::Progress::Theme::Compact.new
-      #   )
+      #   Taski.progress.layout = Taski::Progress::Layout::Simple
+      #   Taski.progress.theme = Taski::Progress::Theme::Compact
       #
       # @example Custom spinner frames
       #   class MoonTheme < Taski::Progress::Theme::Compact

--- a/lib/taski/progress/theme/detail.rb
+++ b/lib/taski/progress/theme/detail.rb
@@ -14,9 +14,8 @@ module Taski
       #   └── ✗ MigrateDB: Connection refused
       #
       # @example Usage
-      #   layout = Taski::Progress::Layout::Tree.new(
-      #     theme: Taski::Progress::Theme::Detail.new
-      #   )
+      #   Taski.progress.layout = Taski::Progress::Layout::Tree
+      #   Taski.progress.theme = Taski::Progress::Theme::Detail
       class Detail < Default
         # Task pending with icon
         def task_pending

--- a/lib/taski/progress/theme/plain.rb
+++ b/lib/taski/progress/theme/plain.rb
@@ -9,9 +9,8 @@ module Taski
       # Outputs plain text without terminal escape codes or colors.
       #
       # @example Usage
-      #   layout = Taski::Progress::Layout::Log.new(
-      #     theme: Taski::Progress::Theme::Plain.new
-      #   )
+      #   Taski.progress.layout = Taski::Progress::Layout::Log
+      #   Taski.progress.theme = Taski::Progress::Theme::Plain
       class Plain < Default
         # === Color configuration (disabled for plain output) ===
 

--- a/lib/taski/task.rb
+++ b/lib/taski/task.rb
@@ -115,7 +115,7 @@ module Taski
       def tree
         output = StringIO.new
         theme = Progress::Theme::Plain.new
-        layout = Progress::Layout::Tree.for(output: output, theme: theme)
+        layout = Progress::Layout::Tree.build(output: output, theme: theme)
         context = Execution::ExecutionFacade.new(root_task_class: self)
         layout.context = context
         layout.on_ready

--- a/test/test_execution_facade.rb
+++ b/test/test_execution_facade.rb
@@ -2,10 +2,32 @@
 
 require "test_helper"
 require "logger"
+require_relative "fixtures/executor_tasks"
 
 class TestExecutionFacade < Minitest::Test
   def setup
     Taski::Task.reset! if defined?(Taski::Task)
+  end
+
+  # teardown_output_capture must close every pipe it created, otherwise the
+  # pipe file descriptors leak until the router is garbage-collected.
+  def test_teardown_output_capture_closes_pipes
+    facade = Taski::Execution::ExecutionFacade.new(root_task_class: ExecutorFixtures::SingleTask)
+    original_stdout = $stdout
+    facade.setup_output_capture($stdout)
+    router = facade.output_capture
+
+    pipe = nil
+    begin
+      router.start_capture(ExecutorFixtures::SingleTask)
+      pipe = router.instance_variable_get(:@pipes)[ExecutorFixtures::SingleTask]
+      refute pipe.closed?, "precondition: pipe should be open before teardown"
+    ensure
+      facade.teardown_output_capture
+    end
+
+    assert_same original_stdout, $stdout, "stdout should be restored after teardown"
+    assert pipe.closed?, "pipe should be closed after teardown_output_capture"
   end
 
   # ========================================

--- a/test/test_executor.rb
+++ b/test/test_executor.rb
@@ -26,6 +26,25 @@ class TestExecutor < Minitest::Test
     assert_includes error.message, "boom in analysis"
   end
 
+  # If the main loop raises (e.g. an unexpected event), the worker pool must
+  # still be shut down and its threads joined, not leaked blocking on queue.pop.
+  def test_worker_threads_shut_down_when_main_loop_raises
+    task_class = ExecutorFixtures::SingleTask
+    registry = Taski::Execution::Registry.new
+    execution_facade = create_execution_facade(registry, task_class)
+    executor = Taski::Execution::Executor.new(registry: registry, execution_facade: execution_facade)
+
+    with_scheduler_finished_raising do
+      assert_raises(RuntimeError) { executor.execute(task_class) }
+    end
+
+    threads = registry.instance_variable_get(:@threads)
+    refute_empty threads, "expected worker threads to have been started"
+    threads.each do |t|
+      assert t.join(5), "worker thread leaked: not shut down when the main loop raised"
+    end
+  end
+
   def test_single_task_no_deps
     task_class = ExecutorFixtures::SingleTask
 
@@ -814,5 +833,16 @@ class TestExecutor < Minitest::Test
     yield
   ensure
     singleton.send(:define_method, :analyze, original)
+  end
+
+  # Temporarily make Scheduler#finished? raise, to force the executor's main
+  # loop to fail after the worker pool has started.
+  def with_scheduler_finished_raising
+    klass = Taski::Execution::Scheduler
+    original = klass.instance_method(:finished?)
+    klass.send(:define_method, :finished?) { |_| raise "boom in main loop" }
+    yield
+  ensure
+    klass.send(:define_method, :finished?, original)
   end
 end

--- a/test/test_layout_base.rb
+++ b/test/test_layout_base.rb
@@ -48,6 +48,16 @@ class TestLayoutBase < Minitest::Test
     assert_equal "", result
   end
 
+  # A RUNTIME template error (Liquid renders in lax mode and does not raise) must
+  # also degrade to "" rather than leaking the literal "Liquid error: ..." text
+  # that Liquid inlines into the output.
+  def test_render_template_string_degrades_runtime_template_errors
+    result = @layout.send(:render_template_string, "{{ 1 | divided_by: 0 }}")
+
+    assert_equal "", result
+    refute_includes result, "Liquid error"
+  end
+
   # === Inheritance tests ===
 
   def test_inherits_from_task_observer

--- a/test/test_layout_base.rb
+++ b/test/test_layout_base.rb
@@ -16,6 +16,38 @@ class TestLayoutBase < Minitest::Test
     @layout = Taski::Progress::Layout::Base.new(output: @output)
   end
 
+  # The spinner timer thread must not die from a divide-by-zero when a custom
+  # theme returns no spinner frames.
+  def test_spinner_timer_survives_empty_spinner_frames
+    theme = Class.new(Taski::Progress::Theme::Base) do
+      def spinner_frames
+        []
+      end
+
+      def spinner_interval
+        0.01
+      end
+    end.new
+    layout = Taski::Progress::Layout::Base.new(output: StringIO.new, theme: theme)
+
+    layout.send(:start_spinner_timer)
+    sleep 0.05
+    timer = layout.instance_variable_get(:@spinner_timer)
+
+    assert timer.alive?, "spinner timer thread died (divide by zero on empty frames)"
+  ensure
+    layout&.send(:stop_spinner_timer)
+  end
+
+  # A malformed theme template must not raise out of render_template_string
+  # (which would silently kill the background render thread). It should degrade
+  # to an empty string instead.
+  def test_render_template_string_handles_malformed_template
+    result = @layout.send(:render_template_string, "{% if true %}never closed")
+
+    assert_equal "", result
+  end
+
   # === Inheritance tests ===
 
   def test_inherits_from_task_observer

--- a/test/test_layout_log.rb
+++ b/test/test_layout_log.rb
@@ -9,7 +9,7 @@ class TestLayoutLog < Minitest::Test
 
   def setup
     @output = StringIO.new
-    @layout = Taski::Progress::Layout::Log.new(output: @output)
+    @layout = Taski::Progress::Layout::Log::Display.new(output: @output)
   end
 
   # === Task lifecycle output ===
@@ -184,7 +184,7 @@ class TestLayoutLog < Minitest::Test
 
   def test_uses_custom_theme
     custom_theme = CustomTestTheme.new
-    layout = Taski::Progress::Layout::Log.new(output: @output, theme: custom_theme)
+    layout = Taski::Progress::Layout::Log::Display.new(output: @output, theme: custom_theme)
 
     task_class = stub_task_class("MyTask")
     layout.on_start

--- a/test/test_layout_simple.rb
+++ b/test/test_layout_simple.rb
@@ -12,14 +12,14 @@ class TestLayoutSimple < Minitest::Test
     @output = StringIO.new
     # Stub tty? to return true for testing
     @output.define_singleton_method(:tty?) { true }
-    @layout = Taski::Progress::Layout::Simple.new(output: @output)
+    @layout = Taski::Progress::Layout::Simple::Display.new(output: @output)
   end
 
   # === TTY detection ===
 
   def test_does_not_activate_for_non_tty
     non_tty_output = StringIO.new
-    layout = Taski::Progress::Layout::Simple.new(output: non_tty_output)
+    layout = Taski::Progress::Layout::Simple::Display.new(output: non_tty_output)
     layout.on_start
     layout.on_stop
 
@@ -98,7 +98,7 @@ class TestLayoutSimple < Minitest::Test
       end
     end.new
 
-    layout = Taski::Progress::Layout::Simple.new(output: @output, theme: custom_theme)
+    layout = Taski::Progress::Layout::Simple::Display.new(output: @output, theme: custom_theme)
     task_a = stub_task_class("TaskA")
     task_b = stub_task_class("TaskB")
     now = Time.now
@@ -177,10 +177,10 @@ class TestLayoutSimpleWithCustomTemplate < Minitest::Test
       end
     end.new
 
-    layout = Taski::Progress::Layout::Simple.new(output: @output, theme: custom_theme)
+    layout = Taski::Progress::Layout::Simple::Display.new(output: @output, theme: custom_theme)
 
     # Verify custom theme is accepted by layout (no error on construction)
-    assert_instance_of Taski::Progress::Layout::Simple, layout
+    assert_instance_of Taski::Progress::Layout::Simple::Display, layout
     assert_equal %w[🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘], custom_theme.spinner_frames
   end
 
@@ -193,10 +193,10 @@ class TestLayoutSimpleWithCustomTemplate < Minitest::Test
       end
     end.new
 
-    layout = Taski::Progress::Layout::Simple.new(output: @output, theme: custom_theme)
+    layout = Taski::Progress::Layout::Simple::Display.new(output: @output, theme: custom_theme)
 
     # Verify custom theme is accepted by layout (no error on construction)
-    assert_instance_of Taski::Progress::Layout::Simple, layout
+    assert_instance_of Taski::Progress::Layout::Simple::Display, layout
     assert_in_delta 0.2, custom_theme.render_interval, 0.001
   end
 
@@ -213,7 +213,7 @@ class TestLayoutSimpleWithCustomTemplate < Minitest::Test
       end
     end.new
 
-    layout = Taski::Progress::Layout::Simple.new(output: @output, theme: custom_theme)
+    layout = Taski::Progress::Layout::Simple::Display.new(output: @output, theme: custom_theme)
     task_class = stub_task_class("MyTask")
     started_at = Time.now
     layout.on_task_updated(task_class, previous_state: nil, current_state: :pending, phase: :run, timestamp: started_at)
@@ -237,7 +237,7 @@ class TestLayoutSimpleWithCustomTemplate < Minitest::Test
       end
     end.new
 
-    layout = Taski::Progress::Layout::Simple.new(output: @output, theme: custom_theme)
+    layout = Taski::Progress::Layout::Simple::Display.new(output: @output, theme: custom_theme)
     task_class = stub_task_class("FailedTask")
     now = Time.now
     layout.on_task_updated(task_class, previous_state: nil, current_state: :pending, phase: :run, timestamp: now)
@@ -260,7 +260,7 @@ class TestLayoutSimpleWithCustomTemplate < Minitest::Test
       end
     end.new
 
-    layout = Taski::Progress::Layout::Simple.new(output: @output, theme: custom_theme)
+    layout = Taski::Progress::Layout::Simple::Display.new(output: @output, theme: custom_theme)
     task_class = stub_task_class("MyTask")
     started_at = Time.now
     layout.on_task_updated(task_class, previous_state: nil, current_state: :pending, phase: :run, timestamp: started_at)
@@ -313,7 +313,7 @@ class TestLayoutSimpleWithCustomTemplate < Minitest::Test
       end
     end.new
 
-    layout = Taski::Progress::Layout::Simple.new(output: @output, theme: custom_theme)
+    layout = Taski::Progress::Layout::Simple::Display.new(output: @output, theme: custom_theme)
     task_class = stub_task_class("TestTask")
     started_at = Time.now
     layout.on_task_updated(task_class, previous_state: nil, current_state: :pending, phase: :run, timestamp: started_at)

--- a/test/test_layout_tree_event.rb
+++ b/test/test_layout_tree_event.rb
@@ -7,31 +7,31 @@ require "taski/progress/theme/default"
 require "taski/progress/theme/plain"
 
 class TestLayoutTreeFactory < Minitest::Test
-  def test_for_returns_live_for_tty_output
+  def test_build_returns_live_for_tty_output
     output = StringIO.new
     output.define_singleton_method(:tty?) { true }
-    layout = Taski::Progress::Layout::Tree.for(output: output)
+    layout = Taski::Progress::Layout::Tree.build(output: output)
     assert_instance_of Taski::Progress::Layout::Tree::Live, layout
   end
 
-  def test_for_returns_event_for_non_tty_output
+  def test_build_returns_event_for_non_tty_output
     output = StringIO.new
-    layout = Taski::Progress::Layout::Tree.for(output: output)
+    layout = Taski::Progress::Layout::Tree.build(output: output)
     assert_instance_of Taski::Progress::Layout::Tree::Event, layout
   end
 
-  def test_for_passes_theme_to_live
+  def test_build_passes_theme_to_live
     output = StringIO.new
     output.define_singleton_method(:tty?) { true }
     theme = Taski::Progress::Theme::Plain.new
-    layout = Taski::Progress::Layout::Tree.for(output: output, theme: theme)
+    layout = Taski::Progress::Layout::Tree.build(output: output, theme: theme)
     assert_instance_of Taski::Progress::Layout::Tree::Live, layout
   end
 
-  def test_for_passes_theme_to_event
+  def test_build_passes_theme_to_event
     output = StringIO.new
     theme = Taski::Progress::Theme::Plain.new
-    layout = Taski::Progress::Layout::Tree.for(output: output, theme: theme)
+    layout = Taski::Progress::Layout::Tree.build(output: output, theme: theme)
     assert_instance_of Taski::Progress::Layout::Tree::Event, layout
   end
 end

--- a/test/test_liquid_tags.rb
+++ b/test/test_liquid_tags.rb
@@ -72,6 +72,21 @@ class TestLiquidTags < Minitest::Test
     assert_equal "-", result2
   end
 
+  def test_spinner_tag_handles_empty_frames_without_dividing_by_zero
+    custom_theme = Class.new(Taski::Progress::Theme::Base) do
+      def spinner_frames
+        []
+      end
+    end.new
+
+    drop = Taski::Progress::Layout::ThemeDrop.new(custom_theme)
+    liquid_template = Liquid::Template.parse("{% spinner %}", environment: @environment)
+    result = liquid_template.render("template" => drop, "spinner_index" => 2)
+
+    assert_equal "", result
+    refute_includes result, "Liquid error"
+  end
+
   def test_spinner_tag_without_theme_drop_uses_default
     liquid_template = Liquid::Template.parse("{% spinner %}", environment: @environment)
     result = liquid_template.render({})

--- a/test/test_logging.rb
+++ b/test/test_logging.rb
@@ -10,7 +10,7 @@ class TestLogging < Minitest::Test
     @log_output = StringIO.new
     @original_logger = Taski.logger
     Taski.reset_progress_display!
-    Taski.progress_display = Taski::Progress::Layout::Log.new
+    Taski.progress_display = Taski::Progress::Layout::Log::Display.new
     Taski::Task.reset!
   end
 

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -23,7 +23,7 @@ class TestMessage < Minitest::Test
 
   def test_progress_display_queue_message_directly
     output = StringIO.new
-    display = Taski::Progress::Layout::Simple.new(output: output)
+    display = Taski::Progress::Layout::Simple::Display.new(output: output)
 
     # Queue messages directly to the display
     display.queue_message("Message 1")
@@ -39,7 +39,7 @@ class TestMessage < Minitest::Test
 
   def test_progress_display_flush_on_stop
     output = StringIO.new
-    display = Taski::Progress::Layout::Simple.new(output: output)
+    display = Taski::Progress::Layout::Simple::Display.new(output: output)
 
     display.on_start
     display.queue_message("Test message")
@@ -85,7 +85,7 @@ class TestMessage < Minitest::Test
       $stdout = output
       $stderr = output
 
-      Taski.progress_display = Taski::Progress::Layout::Log.new(output: output)
+      Taski.progress_display = Taski::Progress::Layout::Log::Display.new(output: output)
       MessageFixtures::MessageOutputTask.run
     ensure
       $stdout = original_stdout
@@ -99,7 +99,7 @@ class TestMessage < Minitest::Test
 
   def test_message_order_preserved_direct
     output = StringIO.new
-    display = Taski::Progress::Layout::Simple.new(output: output)
+    display = Taski::Progress::Layout::Simple::Display.new(output: output)
 
     display.on_start
     display.queue_message("First")
@@ -113,7 +113,7 @@ class TestMessage < Minitest::Test
 
   def test_message_thread_safety_direct
     output = StringIO.new
-    display = Taski::Progress::Layout::Simple.new(output: output)
+    display = Taski::Progress::Layout::Simple::Display.new(output: output)
 
     display.on_start
 
@@ -139,7 +139,7 @@ class TestMessage < Minitest::Test
 
   def test_message_flushed_only_when_nest_level_zero
     output = StringIO.new
-    display = Taski::Progress::Layout::Simple.new(output: output)
+    display = Taski::Progress::Layout::Simple::Display.new(output: output)
 
     # Simulate outer executor start
     display.on_start

--- a/test/test_progress_config.rb
+++ b/test/test_progress_config.rb
@@ -77,7 +77,7 @@ class TestProgressConfig < Minitest::Test
 
   def test_layout_rejects_instance
     config = Taski::Progress::Config.new
-    assert_raises(ArgumentError) { config.layout = Taski::Progress::Layout::Simple.new }
+    assert_raises(ArgumentError) { config.layout = Taski::Progress::Layout::Simple::Display.new }
   end
 
   def test_theme_rejects_instance
@@ -90,28 +90,28 @@ class TestProgressConfig < Minitest::Test
   def test_build_default_returns_simple_layout
     config = Taski::Progress::Config.new
     display = config.build
-    assert_instance_of Taski::Progress::Layout::Simple, display
+    assert_instance_of Taski::Progress::Layout::Simple::Display, display
   end
 
   def test_build_with_layout_class
     config = Taski::Progress::Config.new
     config.layout = Taski::Progress::Layout::Log
     display = config.build
-    assert_instance_of Taski::Progress::Layout::Log, display
+    assert_instance_of Taski::Progress::Layout::Log::Display, display
   end
 
   def test_build_with_theme_class
     config = Taski::Progress::Config.new
     config.theme = Taski::Progress::Theme::Plain
     display = config.build
-    assert_instance_of Taski::Progress::Layout::Simple, display
+    assert_instance_of Taski::Progress::Layout::Simple::Display, display
   end
 
-  def test_build_with_layout_module_uses_for
+  def test_build_with_layout_module_decides_variant
     config = Taski::Progress::Config.new
     config.layout = Taski::Progress::Layout::Tree
     display = config.build
-    # Non-TTY default ($stderr in test is not TTY), so Tree.for returns Event
+    # Non-TTY default ($stderr in test is not TTY), so Tree.build returns Event
     assert_instance_of Taski::Progress::Layout::Tree::Event, display
   end
 
@@ -123,11 +123,12 @@ class TestProgressConfig < Minitest::Test
     assert_instance_of Taski::Progress::Layout::Tree::Event, display
   end
 
-  def test_build_with_layout_class_still_works
+  def test_layout_rejects_internal_tree_variants
     config = Taski::Progress::Config.new
-    config.layout = Taski::Progress::Layout::Tree::Event
-    display = config.build
-    assert_instance_of Taski::Progress::Layout::Tree::Event, display
+    # Tree::Live / Tree::Event are internal; only the public Tree kind is a
+    # layout. They have no .build, so they cannot be forced as a layout directly.
+    assert_raises(ArgumentError) { config.layout = Taski::Progress::Layout::Tree::Event }
+    assert_raises(ArgumentError) { config.layout = Taski::Progress::Layout::Tree::Live }
   end
 
   def test_build_with_output
@@ -135,7 +136,7 @@ class TestProgressConfig < Minitest::Test
     io = StringIO.new
     config.output = io
     display = config.build
-    assert_instance_of Taski::Progress::Layout::Simple, display
+    assert_instance_of Taski::Progress::Layout::Simple::Display, display
   end
 
   # === Invalidation ===
@@ -146,7 +147,7 @@ class TestProgressConfig < Minitest::Test
     config.layout = Taski::Progress::Layout::Log
     display2 = config.build
     refute_same display1, display2
-    assert_instance_of Taski::Progress::Layout::Log, display2
+    assert_instance_of Taski::Progress::Layout::Log::Display, display2
   end
 
   def test_setting_theme_invalidates_display
@@ -182,7 +183,7 @@ class TestProgressConfig < Minitest::Test
 
   def test_taski_progress_display_builds_from_config
     display = Taski.progress_display
-    assert_instance_of Taski::Progress::Layout::Simple, display
+    assert_instance_of Taski::Progress::Layout::Simple::Display, display
   end
 
   def test_taski_progress_display_caches_instance
@@ -196,11 +197,11 @@ class TestProgressConfig < Minitest::Test
     Taski.progress.layout = Taski::Progress::Layout::Log
     display2 = Taski.progress_display
     refute_same display1, display2
-    assert_instance_of Taski::Progress::Layout::Log, display2
+    assert_instance_of Taski::Progress::Layout::Log::Display, display2
   end
 
   def test_taski_progress_display_setter_works
-    custom = Taski::Progress::Layout::Log.new
+    custom = Taski::Progress::Layout::Log::Display.new
     Taski.progress_display = custom
     assert_same custom, Taski.progress_display
   end
@@ -210,6 +211,6 @@ class TestProgressConfig < Minitest::Test
     Taski.reset_progress_display!
     assert_nil Taski.progress.layout
     display = Taski.progress_display
-    assert_instance_of Taski::Progress::Layout::Simple, display
+    assert_instance_of Taski::Progress::Layout::Simple::Display, display
   end
 end

--- a/test/test_simple_progress_display.rb
+++ b/test/test_simple_progress_display.rb
@@ -9,7 +9,7 @@ class TestSimpleProgressDisplay < Minitest::Test
   def setup
     Taski.reset_progress_display!
     @output = StringIO.new
-    @display = Taski::Progress::Layout::Simple.new(output: @output)
+    @display = Taski::Progress::Layout::Simple::Display.new(output: @output)
   end
 
   def teardown
@@ -127,7 +127,7 @@ class TestSimpleProgressDisplayWithTTY < Minitest::Test
   def setup
     Taski.reset_progress_display!
     @output = TTYStringIO.new
-    @display = Taski::Progress::Layout::Simple.new(output: @output)
+    @display = Taski::Progress::Layout::Simple::Display.new(output: @output)
   end
 
   def teardown
@@ -298,7 +298,7 @@ class TestProgressDisplayConfiguration < Minitest::Test
 
   def test_default_progress_display_is_simple
     display = Taski.progress_display
-    assert_instance_of Taski::Progress::Layout::Simple, display
+    assert_instance_of Taski::Progress::Layout::Simple::Display, display
   end
 
   def test_progress_display_can_be_set_to_nil
@@ -307,13 +307,13 @@ class TestProgressDisplayConfiguration < Minitest::Test
   end
 
   def test_progress_display_can_be_set_to_tree
-    tree = Taski::Progress::Layout::Tree.for
+    tree = Taski::Progress::Layout::Tree.build
     Taski.progress_display = tree
     assert_same tree, Taski.progress_display
   end
 
   def test_progress_display_can_be_set_to_log
-    log = Taski::Progress::Layout::Log.new
+    log = Taski::Progress::Layout::Log::Display.new
     Taski.progress_display = log
     assert_same log, Taski.progress_display
   end
@@ -328,7 +328,7 @@ class TestProgressDisplayConfiguration < Minitest::Test
     Taski.progress_display = nil
     Taski.reset_progress_display!
     display = Taski.progress_display
-    assert_instance_of Taski::Progress::Layout::Simple, display
+    assert_instance_of Taski::Progress::Layout::Simple::Display, display
   end
 
   def test_setting_progress_display_stops_previous
@@ -337,7 +337,7 @@ class TestProgressDisplayConfiguration < Minitest::Test
     old_display.define_singleton_method(:stop) { stop_called = true }
     Taski.progress_display = old_display
 
-    Taski.progress_display = Taski::Progress::Layout::Simple.new
+    Taski.progress_display = Taski::Progress::Layout::Simple::Display.new
     assert stop_called, "Previous display should be stopped when setting a new one"
   end
 


### PR DESCRIPTION
## Summary

Resource-cleanup and progress-display hardening, plus a refactor that unifies the progress layouts behind a single `.build` factory.

> Stacked: **#218 builds on this.** Base is `master`.

## Resource cleanup
- `Executor#execute` / `#execute_clean` shut the worker pool down in an `ensure` block — a raise in the main loop no longer leaks worker threads blocked on `queue.pop`.
- `ExecutionFacade#teardown_output_capture` now calls `close_all` after `stop_polling`, releasing every pipe's fds deterministically (`close_all` previously had **no** production caller). `@recent_lines` is untouched, so failure-output reporting still works.

## Progress-display robustness
- `SpinnerTag` and the spinner timer guard against an empty `spinner_frames` (return `""` / skip the increment) instead of a `ZeroDivisionError` that silently killed the timer thread.
- `render_template_string` rescues parse-time `Liquid::SyntaxError` **and** inspects `template.errors` for lax-mode runtime errors (bad filter/tag/drop, e.g. divide-by-zero). Both degrade to `""` and are logged, instead of raising out of the background render thread or leaking literal `"Liquid error: ..."` text into the display.

## Progress layouts: one uniform `.build` factory
Layouts were a mix (Simple/Log classes, Tree module) and `Config#build_display` special-cased Tree (`.for` vs `.new`). Now **every layout is a module exposing `.build(output:, theme:)`** that returns a `Layout::Base` instance and decides its own concrete class:

- `Simple` / `Log` — modules wrapping a single `Simple::Display` / `Log::Display`.
- `Tree` — module whose `.build` picks `Tree::Live` (TTY) or `Tree::Event` (non-TTY).

`Config#build_display` calls `layout.build(**args)` uniformly; `validate_layout!` requires `respond_to?(:build)`, which admits the public layout modules (Simple, Log, Tree, custom) and rejects instances, non-layouts, and the internal display classes (`Simple::Display`, `Tree::Live`/`Tree::Event`) — so a concrete variant can't be forced as a layout. `Tree.for`/`Tree.new` are gone; docs use the `Taski.progress.layout = <Module>` API.

## Verification
`bundle exec rake` (test + standard) → exit 0, **723 runs, 0 failures**. New regression tests cover the worker-shutdown-on-error, pipe close, empty spinner frames, Liquid parse + runtime errors, the `.build` factory, and the sealing of internal variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)