### PR TITLE
Resolve exported values via method_missing so exports never shadow methods

### DIFF
--- a/lib/taski/task.rb
+++ b/lib/taski/task.rb
@@ -81,13 +81,15 @@ module Taski
       # Only fires for names that are not already defined as real methods, so an
       # export can never shadow Module#name / Task.run / etc.
       def method_missing(name, *args, **kwargs, &block)
-        return super unless exported_methods.include?(name)
-        # Only the `args:` keyword (or no argument) is valid; anything else is a
-        # malformed call and should fail fast like a normal method, not silently
-        # resolve and drop the arguments.
-        return super unless args.empty? && (kwargs.keys - [:args]).empty?
-
-        resolve_exported_value(name, kwargs.fetch(:args, {}))
+        # Resolve only a known export, and only for a valid call shape: no
+        # positional args and at most the `args:` keyword. Anything else falls
+        # through to super so a malformed call fails like a normal method instead
+        # of silently resolving and dropping the arguments.
+        if exported_methods.include?(name) && args.empty? && (kwargs.keys - [:args]).empty?
+          resolve_exported_value(name, kwargs.fetch(:args, {}))
+        else
+          super
+        end
       end
 
       def respond_to_missing?(name, include_private = false)
@@ -370,12 +372,14 @@ module Taski
     # that are not already defined as real instance methods, so an export can
     # never shadow an existing method.
     def method_missing(name, *args, &block)
-      return super unless self.class.exported_methods.include?(name)
-      # The instance reader takes no arguments; a call with any (Ruby collects a
-      # trailing keyword hash into *args too) is malformed and must fail fast.
-      return super unless args.empty?
-
-      instance_variable_get("@#{name}")
+      # Resolve a known export only when called with no arguments (Ruby folds a
+      # trailing keyword hash into *args too); otherwise fall through to super so
+      # a malformed call fails fast.
+      if self.class.exported_methods.include?(name) && args.empty?
+        instance_variable_get("@#{name}")
+      else
+        super
+      end
     end
 
     def respond_to_missing?(name, include_private = false)

--- a/lib/taski/task.rb
+++ b/lib/taski/task.rb
@@ -41,10 +41,13 @@ module Taski
       # that name already exists. Colliding names are warned about here.
       # @param export_methods [Array<Symbol>] The method names to export.
       def exports(*export_methods)
-        export_methods.each do |method|
-          warn_export_collision(method) if export_name_collides?(method)
+        names = export_methods.map(&:to_sym)
+        names.each do |name|
+          warn_export_collision(name) if export_name_collides?(name)
         end
-        @exported_methods = export_methods
+        # Accumulate so repeated `exports` calls add to, rather than clobber,
+        # the set. method_missing resolves names as Symbols, so normalize here.
+        @exported_methods = (@exported_methods || []) | names
       end
 
       ##
@@ -197,14 +200,18 @@ module Taski
       end
 
       ##
-      # Warn that an export name collides with an existing method and so cannot
-      # be reached as an accessor.
+      # Warn that an export name collides with an existing method. Resolution
+      # goes through method_missing, which only fires for *undefined* names, so a
+      # public method of the same name shadows the export (the method wins) while
+      # a private one leaves resolution ambiguous (an external call reaches the
+      # export, an internal one the private method). Either way the name is
+      # unreliable, so warn.
       # @param method [Symbol] The colliding export name.
       def warn_export_collision(method)
-        warn "Taski: #{self} exports :#{method}, but :#{method} already exists as a method " \
-          "on the class or its instances. #{self}.#{method} (and instance ##{method}) keep their " \
-          "existing behavior, so the exported value is NOT reachable through that name. " \
-          "Choose a different export name."
+        warn "Taski: #{self} exports :#{method}, but a method named :#{method} already exists. " \
+          "An existing method can take precedence over the export, so #{self}.#{method} " \
+          "(and instance ##{method}) may not return the exported value. " \
+          "Choose a different export name to avoid the ambiguity."
       end
 
       ##
@@ -364,6 +371,9 @@ module Taski
     # never shadow an existing method.
     def method_missing(name, *args, &block)
       return super unless self.class.exported_methods.include?(name)
+      # The instance reader takes no arguments; a call with any (Ruby collects a
+      # trailing keyword hash into *args too) is malformed and must fail fast.
+      return super unless args.empty?
 
       instance_variable_get("@#{name}")
     end

--- a/lib/taski/task.rb
+++ b/lib/taski/task.rb
@@ -35,15 +35,18 @@ module Taski
 
       ##
       # Declares exported methods that will be accessible after task execution.
-      # Creates instance reader and class accessor methods for each export.
+      # Exported values are resolved lazily through method_missing, so an export
+      # never overrides an existing method (Module#name, Task.run, ...) — it is
+      # only reachable as +Task.method+ / +instance.method+ when no method of
+      # that name already exists. Colliding names are warned about here.
       # @param export_methods [Array<Symbol>] The method names to export.
       def exports(*export_methods)
-        @exported_methods = export_methods
-
         export_methods.each do |method|
-          define_instance_reader(method)
-          define_class_accessor(method)
+          if singleton_class.method_defined?(method) || method_defined?(method)
+            warn_export_collision(method)
+          end
         end
+        @exported_methods = export_methods
       end
 
       ##
@@ -51,6 +54,20 @@ module Taski
       # @return [Array<Symbol>] The exported method names.
       def exported_methods
         @exported_methods ||= []
+      end
+
+      ##
+      # Resolves an exported value when called as Task.<export> on the class.
+      # Only fires for names that are not already defined as real methods, so an
+      # export can never shadow Module#name / Task.run / etc.
+      def method_missing(name, *args, **kwargs, &block)
+        return super unless exported_methods.include?(name)
+
+        resolve_exported_value(name, kwargs.fetch(:args, {}))
+      end
+
+      def respond_to_missing?(name, include_private = false)
+        exported_methods.include?(name) || super
       end
 
       private :new
@@ -159,62 +176,59 @@ module Taski
       end
 
       ##
-      # Defines an instance reader method for an exported value.
-      # @param method [Symbol] The method name to define.
-      def define_instance_reader(method)
-        undef_method(method) if method_defined?(method)
-
-        define_method(method) do
-          # @type self: Task
-          instance_variable_get("@#{method}")
-        end
+      # Warn that an export name collides with an existing method and so cannot
+      # be reached as an accessor.
+      # @param method [Symbol] The colliding export name.
+      def warn_export_collision(method)
+        warn "Taski: #{self} exports :#{method}, but :#{method} already exists as a method " \
+          "on the class or its instances. #{self}.#{method} (and instance ##{method}) keep their " \
+          "existing behavior, so the exported value is NOT reachable through that name. " \
+          "Choose a different export name."
       end
 
       ##
-      # Defines a class accessor method for an exported value.
-      # When called inside an execution, returns cached value from registry.
-      # When called outside execution, creates fresh execution.
-      # @param method [Symbol] The method name to define.
-      def define_class_accessor(method)
-        singleton_class.undef_method(method) if singleton_class.method_defined?(method)
-
-        define_singleton_method(method) do |args: {}|
-          registry = Taski.current_registry
-          if registry
-            unless args.empty?
-              warn "Taski: args: passed to #{self}.#{method} is ignored inside an execution context"
-            end
-            if Thread.current[:taski_fiber_context]
-              start_deps = Thread.current[:taski_start_deps]
-              if start_deps&.include?(self)
-                # Lazy resolution via proxy - safe dep confirmed by static analysis
-                TaskProxy.new(self, method)
-              else
-                # Synchronous resolution: dep not in allowlist (unknown or unsafe usage)
-                result = Fiber.yield(Taski::Execution::FiberProtocol::NeedDep.new(self, method))
-                raise result.error if result in Taski::Execution::FiberProtocol::DepError
-                result
-              end
+      # Resolve an exported value for a Task.<export> call.
+      # When called inside an execution, returns the cached value from the
+      # registry (or a proxy / synchronous Fiber pull during the run phase).
+      # When called outside execution, creates a fresh execution.
+      # @param method [Symbol] The exported method name.
+      # @param args [Hash] User-defined arguments (only honored outside execution).
+      def resolve_exported_value(method, args)
+        registry = Taski.current_registry
+        if registry
+          unless args.empty?
+            warn "Taski: args: passed to #{self}.#{method} is ignored inside an execution context"
+          end
+          if Thread.current[:taski_fiber_context]
+            start_deps = Thread.current[:taski_start_deps]
+            if start_deps&.include?(self)
+              # Lazy resolution via proxy - safe dep confirmed by static analysis
+              TaskProxy.new(self, method)
             else
-              # Synchronous resolution (clean phase, outside Fiber)
-              wrapper = registry.get_or_create(self) do
-                task_instance = allocate
-                task_instance.__send__(:initialize)
-                Execution::TaskWrapper.new(
-                  task_instance,
-                  registry: registry,
-                  execution_facade: Execution::ExecutionFacade.current
-                )
-              end
-              wrapper.get_exported_value(method)
+              # Synchronous resolution: dep not in allowlist (unknown or unsafe usage)
+              result = Fiber.yield(Taski::Execution::FiberProtocol::NeedDep.new(self, method))
+              raise result.error if result in Taski::Execution::FiberProtocol::DepError
+              result
             end
           else
-            # Outside execution - fresh execution (top-level call)
-            Taski.send(:with_env, root_task: self) do
-              Taski.send(:with_args, options: args) do
-                validate_no_circular_dependencies!
-                fresh_wrapper.get_exported_value(method)
-              end
+            # Synchronous resolution (clean phase, outside Fiber)
+            wrapper = registry.get_or_create(self) do
+              task_instance = allocate
+              task_instance.__send__(:initialize)
+              Execution::TaskWrapper.new(
+                task_instance,
+                registry: registry,
+                execution_facade: Execution::ExecutionFacade.current
+              )
+            end
+            wrapper.get_exported_value(method)
+          end
+        else
+          # Outside execution - fresh execution (top-level call)
+          Taski.send(:with_env, root_task: self) do
+            Taski.send(:with_args, options: args) do
+              validate_no_circular_dependencies!
+              fresh_wrapper.get_exported_value(method)
             end
           end
         end
@@ -321,6 +335,20 @@ module Taski
       self.class.exported_methods.each do |method|
         instance_variable_set("@#{method}", nil)
       end
+    end
+
+    ##
+    # Reads an exported value (instance.<export>). Only fires for export names
+    # that are not already defined as real instance methods, so an export can
+    # never shadow an existing method.
+    def method_missing(name, *args, &block)
+      return super unless self.class.exported_methods.include?(name)
+
+      instance_variable_get("@#{name}")
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      self.class.exported_methods.include?(name) || super
     end
   end
 end

--- a/lib/taski/task.rb
+++ b/lib/taski/task.rb
@@ -42,18 +42,35 @@ module Taski
       # @param export_methods [Array<Symbol>] The method names to export.
       def exports(*export_methods)
         export_methods.each do |method|
-          if singleton_class.method_defined?(method) || method_defined?(method)
-            warn_export_collision(method)
-          end
+          warn_export_collision(method) if export_name_collides?(method)
         end
         @exported_methods = export_methods
       end
 
       ##
-      # Returns the list of exported method names.
+      # Whether an export name is already a method (so the accessor won't be
+      # reachable). Checks public + private, on the class (singleton) and on
+      # instances, but ignores the generic Module/Class/Object/Kernel methods
+      # every class has, so we only warn about real collisions (Ruby/Taski public
+      # API and user-/Taski-defined private methods).
+      def export_name_collides?(method)
+        singleton_class.method_defined?(method) ||
+          method_defined?(method) ||
+          (singleton_class.private_method_defined?(method) && !Class.private_method_defined?(method)) ||
+          (private_method_defined?(method) && !Object.private_method_defined?(method))
+      end
+
+      ##
+      # Returns the list of exported method names, including those inherited from
+      # parent task classes. Resolution (method_missing) and several internal
+      # consumers gate on this list, so it must walk the ancestor chain — a
+      # subclass that inherits exports without re-declaring them still resolves
+      # them, and a subclass adding an export keeps the inherited ones.
       # @return [Array<Symbol>] The exported method names.
       def exported_methods
-        @exported_methods ||= []
+        own = (@exported_methods ||= [])
+        inherited = superclass.respond_to?(:exported_methods) ? superclass.exported_methods : []
+        inherited | own
       end
 
       ##
@@ -62,6 +79,10 @@ module Taski
       # export can never shadow Module#name / Task.run / etc.
       def method_missing(name, *args, **kwargs, &block)
         return super unless exported_methods.include?(name)
+        # Only the `args:` keyword (or no argument) is valid; anything else is a
+        # malformed call and should fail fast like a normal method, not silently
+        # resolve and drop the arguments.
+        return super unless args.empty? && (kwargs.keys - [:args]).empty?
 
         resolve_exported_value(name, kwargs.fetch(:args, {}))
       end

--- a/lib/taski/test_helper.rb
+++ b/lib/taski/test_helper.rb
@@ -18,20 +18,16 @@ module Taski
   #     end
   #   end
   module TestHelper
-    # Module prepended to Task's singleton class to intercept define_class_accessor.
-    # Wraps the original accessor with a mock check.
+    # Module prepended to Task's singleton class to intercept exported-value
+    # resolution. Returns the mock value when the task is mocked, otherwise
+    # delegates to the real resolution.
     # @api private
     module TaskExtension
-      def define_class_accessor(method)
+      def resolve_exported_value(method, args)
+        mock = MockRegistry.mock_for(self)
+        return mock.get_exported_value(method) if mock
+
         super
-        original_method = self.method(method)
-
-        define_singleton_method(method) do |args: {}|
-          mock = MockRegistry.mock_for(self)
-          return mock.get_exported_value(method) if mock
-
-          original_method.call(args: args)
-        end
       end
     end
 

--- a/test/fixtures/reserved_export_tasks.rb
+++ b/test/fixtures/reserved_export_tasks.rb
@@ -15,4 +15,37 @@ module ReservedExportFixtures
       @name = "artifact-name"
     end
   end
+
+  # Subclass inheritance of exports.
+  class BaseExport < Taski::Task
+    exports :value
+
+    def run
+      @value = "base-value"
+    end
+  end
+
+  # Inherits :value (and run) without re-declaring.
+  class InheritsExport < BaseExport
+  end
+
+  # Adds its own export on top of the inherited one.
+  class AddsExport < BaseExport
+    exports :extra
+
+    def run
+      @value = "base-value"
+      @extra = "extra-value"
+    end
+  end
+
+  # Depends on a subclass that inherits its export — exercises the
+  # public_send(:value) path through the registry/proxy resolution.
+  class ConsumesInherited < Taski::Task
+    exports :combined
+
+    def run
+      @combined = "got: #{InheritsExport.value}"
+    end
+  end
 end

--- a/test/fixtures/reserved_export_tasks.rb
+++ b/test/fixtures/reserved_export_tasks.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "taski"
+
+# Fixture for verifying that exporting a name which collides with an existing
+# method (here Module#name) no longer breaks the framework. With method_missing
+# resolution, `ExportsName.name` keeps Module#name's behavior (returns the class
+# name) and static analysis / execution work normally; the :name export is
+# simply unreachable via `.name`.
+module ReservedExportFixtures
+  class ExportsName < Taski::Task
+    exports :name
+
+    def run
+      @name = "artifact-name"
+    end
+  end
+end

--- a/test/fixtures/reserved_export_tasks.rb
+++ b/test/fixtures/reserved_export_tasks.rb
@@ -48,4 +48,26 @@ module ReservedExportFixtures
       @combined = "got: #{InheritsExport.value}"
     end
   end
+
+  # Two `exports` calls on one class — both names must resolve (accumulate, not
+  # clobber the earlier call).
+  class TwiceExports < Taski::Task
+    exports :first
+    exports :second
+
+    def run
+      @first = "first-value"
+      @second = "second-value"
+    end
+  end
+
+  # Export name given as a String must work the same as a Symbol, because the
+  # call site (method_missing) always receives a Symbol.
+  class StringExport < Taski::Task
+    exports "strval"
+
+    def run
+      @strval = "string-export-value"
+    end
+  end
 end

--- a/test/test_reserved_exports.rb
+++ b/test/test_reserved_exports.rb
@@ -49,4 +49,44 @@ class TestReservedExports < Minitest::Test
     end
     assert_empty err
   end
+
+  # A subclass that inherits exports without re-declaring them must still be able
+  # to resolve those exports (exported_methods walks the ancestor chain).
+  def test_subclass_inherits_parent_exports
+    assert_equal "base-value", ReservedExportFixtures::InheritsExport.value
+  end
+
+  # A subclass that adds an export keeps the inherited ones too (merge, not clobber).
+  def test_subclass_adding_an_export_keeps_inherited_exports
+    assert_equal "base-value", ReservedExportFixtures::AddsExport.value
+    assert_equal "extra-value", ReservedExportFixtures::AddsExport.extra
+  end
+
+  # A task depending on a subclass's inherited export resolves it through the
+  # execution pipeline (public_send → instance method_missing).
+  def test_dependent_task_can_read_subclass_inherited_export
+    assert_equal "got: base-value", ReservedExportFixtures::ConsumesInherited.combined
+  end
+
+  # Collision detection must also catch already-defined PRIVATE methods (the
+  # accessor still won't be reachable externally).
+  def test_exports_warns_when_name_collides_with_a_private_method
+    _out, err = capture_io do
+      Class.new(Taski::Task) do
+        def secret
+          1
+        end
+        private :secret
+        exports :secret
+      end
+    end
+    assert_match(/secret/, err)
+  end
+
+  # A malformed accessor call (positional or unknown-keyword args) must fail fast
+  # rather than silently resolving and dropping the args.
+  def test_export_accessor_rejects_malformed_args
+    assert_raises(NoMethodError) { ReservedExportFixtures::BaseExport.value(123) }
+    assert_raises(NoMethodError) { ReservedExportFixtures::BaseExport.value(bogus: 1) }
+  end
 end

--- a/test/test_reserved_exports.rb
+++ b/test/test_reserved_exports.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "fixtures/reserved_export_tasks"
+
+class TestReservedExports < Minitest::Test
+  def setup
+    Taski::Task.reset! if defined?(Taski::Task)
+  end
+
+  # exports :name must not shadow Module#name in a way that breaks the framework.
+  # Class.name should keep returning the real class name (used by static analysis,
+  # logging, errors), not the export accessor.
+  def test_exports_name_does_not_shadow_module_name
+    klass = ReservedExportFixtures::ExportsName
+    assert_equal "ReservedExportFixtures::ExportsName", klass.name
+  end
+
+  # Static analysis of a task that exports :name must not infinitely recurse.
+  def test_exports_name_does_not_crash_static_analysis
+    deps = nil
+    Timeout.timeout(5) do
+      deps = Taski::StaticAnalysis::Analyzer.analyze(ReservedExportFixtures::ExportsName)
+    end
+    assert_kind_of Enumerable, deps
+  end
+
+  # A task that exports :name must still be runnable.
+  def test_exports_name_task_is_runnable
+    Timeout.timeout(10) do
+      ReservedExportFixtures::ExportsName.run(workers: 1)
+    end
+  end
+
+  # Exporting a name that is already a defined method (so the accessor can't be
+  # reached) must warn at definition time instead of silently shadowing it.
+  def test_exports_warns_when_name_collides_with_existing_method
+    _out, err = capture_io do
+      Class.new(Taski::Task) { exports :name }
+    end
+    assert_match(/name/, err)
+    assert_match(/exist/i, err)
+  end
+
+  # A non-colliding export name stays fully functional (no warning, reachable).
+  def test_non_colliding_export_is_unaffected
+    _out, err = capture_io do
+      Class.new(Taski::Task) { exports :totally_custom_value }
+    end
+    assert_empty err
+  end
+end

--- a/test/test_reserved_exports.rb
+++ b/test/test_reserved_exports.rb
@@ -68,8 +68,9 @@ class TestReservedExports < Minitest::Test
     assert_equal "got: base-value", ReservedExportFixtures::ConsumesInherited.combined
   end
 
-  # Collision detection must also catch already-defined PRIVATE methods (the
-  # accessor still won't be reachable externally).
+  # Collision detection must also catch already-defined PRIVATE methods: an
+  # external `.secret` call reaches the export via method_missing while an
+  # internal `secret` call hits the private method, so the name is ambiguous.
   def test_exports_warns_when_name_collides_with_a_private_method
     _out, err = capture_io do
       Class.new(Taski::Task) do
@@ -88,5 +89,34 @@ class TestReservedExports < Minitest::Test
   def test_export_accessor_rejects_malformed_args
     assert_raises(NoMethodError) { ReservedExportFixtures::BaseExport.value(123) }
     assert_raises(NoMethodError) { ReservedExportFixtures::BaseExport.value(bogus: 1) }
+  end
+
+  # Multiple `exports` calls on the same class accumulate; an earlier export must
+  # not be clobbered by a later one.
+  def test_multiple_exports_calls_accumulate
+    assert_equal "first-value", ReservedExportFixtures::TwiceExports.first
+    assert_equal "second-value", ReservedExportFixtures::TwiceExports.second
+  end
+
+  # An export name passed as a String resolves the same as a Symbol — exports
+  # must normalize, because method_missing always receives the name as a Symbol.
+  def test_string_export_name_resolves
+    assert_equal "string-export-value", ReservedExportFixtures::StringExport.strval
+  end
+
+  # The instance-level export reader takes no arguments; passing any must fail
+  # fast (NoMethodError) rather than silently dropping them.
+  def test_instance_export_reader_rejects_extra_args
+    inst = TaskiTestHelper.build_task_instance(ReservedExportFixtures::BaseExport)
+    assert_raises(NoMethodError) { inst.value(123) }
+  end
+
+  # Generic Kernel/Object private methods (format, gets, ...) are excluded from
+  # collision detection, so exporting such a name must not warn.
+  def test_exports_does_not_warn_for_generic_kernel_method_names
+    _out, err = capture_io do
+      Class.new(Taski::Task) { exports :format }
+    end
+    assert_empty err
   end
 end


### PR DESCRIPTION
## Summary

Replaces the `exports` accessor mechanism with `method_missing` resolution so an export can never shadow an existing method — fixing the `exports :name` → `SystemStackError` crash — plus review follow-ups for subclass inheritance, private-method collisions, and arg arity.

> Stacked on **#217**. Base is `fix/resource-and-display-hardening`.

## The bug

`exports :X` defined a concrete singleton method `Task.X` (via `define_class_accessor`), **undef-ing any existing method of that name**. `exports :name` therefore replaced `Module#name`; the static analyzer (and ~27 other sites) call `task_class.name`, so it re-entered execution → infinite recursion → `SystemStackError` on the **first** analyze/run. (This was earlier misdiagnosed as a "Prism concurrency bug.")

## The fix

Resolve exports lazily through `method_missing`, which only fires for **undefined** names:

- `Task.exports` records the names and **warns** on a collision (the accessor won't be reachable).
- Class- and instance-level `method_missing` / `respond_to_missing?` resolve the export; the old accessor body moved into a private `resolve_exported_value`.
- Existing methods (`Module#name`, `Task.run`, ...) are never overridden, so collisions can't crash — and no hardening of the 27 `task_class.name` sites is needed.
- `TestHelper::TaskExtension` hooks `resolve_exported_value` for mocking.

## Review follow-ups

- **Subclass export inheritance** (regression): `exported_methods` now walks the ancestor chain, so a subclass that inherits exports (without re-declaring) still resolves them, and one that adds an export keeps the inherited ones.
- **Collision check** now also catches already-defined **private** methods (excluding generic Object/Class/Kernel ones).
- **Class `method_missing`** fails fast (falls through to `NoMethodError`) on a malformed call (positional / unknown-keyword args) instead of silently dropping them.

## Verification
`bundle exec rake` (test + standard) → exit 0, **723 runs, 0 failures**. `test/test_reserved_exports.rb` covers `exports :name` not shadowing `Module#name`, subclass inheritance (direct + as a dependency), private-method collision warnings, and malformed-arg rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export inheritance now properly accumulates across subclasses
  * Multiple `exports` declarations on the same class now accumulate instead of overwriting
  * String export names are now supported alongside symbol exports

* **Improvements**
  * Collision warnings emitted when export names conflict with existing methods
  * Enhanced export resolution robustness for reserved method names

<!-- end of auto-generated comment: release notes by coderabbit.ai -->