### PR TITLE
Replace request_value symbol tuples with FiberProtocol Data types

### DIFF
--- a/lib/taski/execution/fiber_protocol.rb
+++ b/lib/taski/execution/fiber_protocol.rb
@@ -17,6 +17,13 @@ module Taski
       CleanCompleted = Data.define(:task_class, :wrapper)
       CleanFailed = Data.define(:task_class, :wrapper, :error)
 
+      # === request_value outcome (TaskWrapper -> WorkerPool#handle_dependency) ===
+      # How a NeedDep should be resolved, based on the dependency's current state.
+      DepCompleted = Data.define(:value) # already done; resume immediately with value
+      DepFailed = Data.define(:error)    # already failed; propagate the error
+      DepWaiting = Data.define           # running; caller parked, resumed via its queue
+      DepStarting = Data.define          # was pending, now running; caller must drive it
+
       # === handle_dependency outcome (worker pool internal) ===
       # Tells drive_fiber_loop how to proceed after resolving a NeedDep.
       ResumeWith = Data.define(:value) # resume the parent fiber with this value

--- a/lib/taski/execution/task_wrapper.rb
+++ b/lib/taski/execution/task_wrapper.rb
@@ -105,27 +105,26 @@ module Taski
       end
 
       # Atomically resolve the dependency value for a waiting Fiber.
-      # Returns a status tuple indicating how the caller should proceed:
-      # - [:completed, value] → dependency already done, resume immediately
-      # - [:failed, error]   → dependency failed, propagate error
-      # - [:wait]            → dependency running, Fiber parked (will be resumed via thread_queue)
-      # - [:start]           → dependency was PENDING, now RUNNING (caller must drive it)
+      # Returns a FiberProtocol value indicating how the caller should proceed:
+      # - DepCompleted(value) → dependency already done, resume immediately
+      # - DepFailed(error)    → dependency failed, propagate error
+      # - DepWaiting          → dependency running, Fiber parked (resumed via thread_queue)
+      # - DepStarting         → dependency was PENDING, now RUNNING (caller must drive it)
       def request_value(method, thread_queue, fiber)
         @monitor.synchronize do
           case @state
           when STATE_COMPLETED
-            value = @task.public_send(method)
-            [:completed, value]
+            FiberProtocol::DepCompleted.new(@task.public_send(method))
           when STATE_FAILED
-            [:failed, @error]
+            FiberProtocol::DepFailed.new(@error)
           when STATE_RUNNING
             @waiters << [thread_queue, fiber, method]
-            [:wait]
+            FiberProtocol::DepWaiting.new
           else
             # PENDING → atomically transition to RUNNING
             @state = STATE_RUNNING
             @waiters << [thread_queue, fiber, method]
-            [:start]
+            FiberProtocol::DepStarting.new
           end
         end
       end

--- a/lib/taski/execution/worker_pool.rb
+++ b/lib/taski/execution/worker_pool.rb
@@ -15,10 +15,11 @@ module Taski
     # - StartDep(task_class)          → non-blocking. Starts dep on another
     #   thread and resumes the Fiber immediately. Used for speculative prestart.
     # - NeedDep(task_class, method)   → blocking. Resolves dependency via
-    #   TaskWrapper#request_value:
-    #   - :completed → resume Fiber immediately with the value
-    #   - :wait → park the Fiber (it will be resumed later via the thread's queue)
-    #   - :start → start the dependency as a nested Fiber on the same thread
+    #   TaskWrapper#request_value, which returns one of:
+    #   - DepCompleted(value) → resume Fiber immediately with the value
+    #   - DepFailed(error)    → resume the Fiber with a DepError to propagate
+    #   - DepWaiting          → park the Fiber (resumed later via the thread's queue)
+    #   - DepStarting         → start the dependency as a nested Fiber on this thread
     #
     # Worker threads process these commands (FiberProtocol Data classes):
     # - Execute(task_class, wrapper)       → create and drive a new Fiber
@@ -173,17 +174,16 @@ module Taski
       #                                      let a later queue event resume the fiber.
       def handle_dependency(dep_class, method, fiber, task_class, wrapper, queue)
         dep_wrapper = @registry.create_wrapper(dep_class, execution_facade: @execution_facade)
-        status = dep_wrapper.request_value(method, queue, fiber)
 
-        case status[0]
-        when :completed
-          FiberProtocol::ResumeWith.new(status[1])
-        when :failed
-          FiberProtocol::ResumeWith.new(FiberProtocol::DepError.new(status[1]))
-        when :wait
+        case dep_wrapper.request_value(method, queue, fiber)
+        in FiberProtocol::DepCompleted(value:)
+          FiberProtocol::ResumeWith.new(value)
+        in FiberProtocol::DepFailed(error:)
+          FiberProtocol::ResumeWith.new(FiberProtocol::DepError.new(error))
+        in FiberProtocol::DepWaiting
           store_fiber_context(fiber, task_class, wrapper)
           FiberProtocol::Parked.new
-        when :start
+        in FiberProtocol::DepStarting
           store_fiber_context(fiber, task_class, wrapper)
           # dep_wrapper is already RUNNING (set atomically by request_value)
           drive_fiber(dep_class, dep_wrapper, queue)

--- a/test/test_task_wrapper.rb
+++ b/test/test_task_wrapper.rb
@@ -29,8 +29,8 @@ class TestTaskWrapper < Minitest::Test
     fiber = Fiber.new { Fiber.yield }
 
     result = wrapper.request_value(:value, thread_queue, fiber)
-    assert_equal :completed, result[0]
-    assert_equal "completed_value", result[1]
+    assert_instance_of Taski::Execution::FiberProtocol::DepCompleted, result
+    assert_equal "completed_value", result.value
   end
 
   def test_request_value_on_failed_wrapper_returns_error
@@ -50,8 +50,8 @@ class TestTaskWrapper < Minitest::Test
     fiber = Fiber.new { Fiber.yield }
 
     result = wrapper.request_value(:value, thread_queue, fiber)
-    assert_equal :failed, result[0]
-    assert_equal error, result[1]
+    assert_instance_of Taski::Execution::FiberProtocol::DepFailed, result
+    assert_equal error, result.error
   end
 
   def test_request_value_on_running_wrapper_returns_wait
@@ -69,7 +69,7 @@ class TestTaskWrapper < Minitest::Test
     fiber = Fiber.new { Fiber.yield }
 
     result = wrapper.request_value(:value, thread_queue, fiber)
-    assert_equal :wait, result[0]
+    assert_instance_of Taski::Execution::FiberProtocol::DepWaiting, result
   end
 
   def test_request_value_on_pending_wrapper_returns_start_and_transitions_to_running
@@ -86,7 +86,7 @@ class TestTaskWrapper < Minitest::Test
     fiber = Fiber.new { Fiber.yield }
 
     result = wrapper.request_value(:value, thread_queue, fiber)
-    assert_equal :start, result[0]
+    assert_instance_of Taski::Execution::FiberProtocol::DepStarting, result
     assert_equal Taski::Execution::TaskWrapper::STATE_RUNNING, wrapper.state
   end
 
@@ -106,10 +106,10 @@ class TestTaskWrapper < Minitest::Test
     fiber_b = Fiber.new { Fiber.yield }
 
     result_a = wrapper.request_value(:value, queue_a, fiber_a)
-    assert_equal :start, result_a[0]
+    assert_instance_of Taski::Execution::FiberProtocol::DepStarting, result_a
 
     result_b = wrapper.request_value(:value, queue_b, fiber_b)
-    assert_equal :wait, result_b[0]
+    assert_instance_of Taski::Execution::FiberProtocol::DepWaiting, result_b
   end
 
   def test_mark_completed_notifies_fiber_waiters
@@ -211,11 +211,11 @@ class TestTaskWrapper < Minitest::Test
     }
     threads.each(&:join)
 
-    start_count = results.count { |r| r[0] == :start }
-    wait_count = results.count { |r| r[0] == :wait }
+    start_count = results.count { |r| r.is_a?(Taski::Execution::FiberProtocol::DepStarting) }
+    wait_count = results.count { |r| r.is_a?(Taski::Execution::FiberProtocol::DepWaiting) }
 
-    assert_equal 1, start_count, "Exactly one thread should get :start"
-    assert_equal 2, wait_count, "Other threads should get :wait"
+    assert_equal 1, start_count, "Exactly one thread should get DepStarting"
+    assert_equal 2, wait_count, "Other threads should get DepWaiting"
   end
 
   private


### PR DESCRIPTION
## What

`TaskWrapper#request_value` returned implicit symbol tuples to signal how a dependency should be resolved:

- `[:completed, value]` — already done, resume immediately
- `[:failed, error]` — already failed, propagate
- `[:wait]` — running, fiber parked
- `[:start]` — was pending, now running, caller must drive it

Its sole runtime consumer, `WorkerPool#handle_dependency`, decoded these positionally via `status[0]` / `status[1]`. This is the same untyped-tuple smell the #212 `ResumeWith`/`Parked` cleanup removed from the driver loop.

## Change

Add four `FiberProtocol` Data types — `DepCompleted(value)`, `DepFailed(error)`, `DepWaiting`, `DepStarting` — and have `request_value` return them. `handle_dependency` now pattern-matches by type (`in FiberProtocol::DepCompleted(value:)`) instead of indexing an array.

Pure type-safety refactor — **behavior is unchanged**. The `request_value` unit tests in `test_task_wrapper.rb` now assert on the Data types, and the stale `worker_pool` protocol doc comment is updated.

## Verification

- `rake test` — 713 runs, 0 failures
- `rake standard` — clean

Independent of the #218 exports stack (touches only `execution/`), so it can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)