### PR TITLE
Make clear_dependency_cache fully invalidate per-class analysis

### DIFF
--- a/lib/taski/static_analysis/start_dep_analyzer.rb
+++ b/lib/taski/static_analysis/start_dep_analyzer.rb
@@ -52,6 +52,13 @@ module Taski
         def clear_cache!
           @cache_mutex.synchronize { @cache.clear }
         end
+
+        # Drop the cached analysis for a single task class, so it is recomputed
+        # the next time it is analyzed (used by Task.clear_dependency_cache).
+        # @param task_class [Class] The task class to evict
+        def clear_cache_for(task_class)
+          @cache_mutex.synchronize { @cache.delete(task_class) }
+        end
       end
 
       EMPTY_RESULT = AnalysisResult.new(start_deps: Set.new.freeze, sync_deps: Set.new.freeze).freeze

--- a/lib/taski/task.rb
+++ b/lib/taski/task.rb
@@ -64,10 +64,15 @@ module Taski
       end
 
       ##
-      # Clears the cached dependency analysis.
+      # Clears the cached dependency analysis for this class.
       # Useful when task code has changed and dependencies need to be re-analyzed.
+      # Invalidates every per-class memo: the dependency set, the circular-check
+      # result (so a newly-introduced cycle is caught), and the StartDepAnalyzer
+      # prestart cache.
       def clear_dependency_cache
         @dependencies_cache = nil
+        @circular_dependency_checked = false
+        StaticAnalysis::StartDepAnalyzer.clear_cache_for(self)
       end
 
       ##

--- a/test/test_clear_dependency_cache.rb
+++ b/test/test_clear_dependency_cache.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "fixtures/start_dep_tasks"
+
+# Taski::Task.clear_dependency_cache is the public hook for "this task's code
+# changed, re-analyze it". It must fully invalidate the per-class analysis:
+# the dependency cache, the memoized circular-dependency check, and the
+# StartDepAnalyzer (prestart) cache.
+class TestClearDependencyCache < Minitest::Test
+  def setup
+    Taski::Task.reset! if defined?(Taski::Task)
+    Taski::StaticAnalysis::StartDepAnalyzer.clear_cache!
+  end
+
+  def teardown
+    # Drop any per-class memo state these tests deliberately populated/invalidated.
+    StartDepFixtures::SlowDepA.clear_dependency_cache
+    StartDepFixtures::ParallelStartDepRoot.clear_dependency_cache
+    Taski::StaticAnalysis::StartDepAnalyzer.clear_cache!
+  end
+
+  # After clear_dependency_cache, a dependency change that introduces a cycle
+  # must be caught on the next validation — the memoized "already checked" flag
+  # must not short-circuit it.
+  def test_clear_dependency_cache_forces_circular_recheck
+    klass = StartDepFixtures::SlowDepA
+    klass.send(:validate_no_circular_dependencies!) # passes; result is memoized
+
+    with_cyclic_components do
+      # Without clearing, the memoized pass short-circuits — no re-check.
+      klass.send(:validate_no_circular_dependencies!) # must NOT raise
+
+      klass.clear_dependency_cache
+
+      # After clearing, validation re-runs and sees the (now cyclic) graph.
+      assert_raises(Taski::CircularDependencyError) do
+        klass.send(:validate_no_circular_dependencies!)
+      end
+    end
+  end
+
+  # clear_dependency_cache must also drop this class's StartDepAnalyzer entry so
+  # prestart analysis is recomputed after a code change.
+  def test_clear_dependency_cache_clears_start_dep_analysis
+    klass = StartDepFixtures::ParallelStartDepRoot
+    Taski::StaticAnalysis::StartDepAnalyzer.analyze(klass)
+    assert start_dep_cached?(klass), "precondition: prestart analysis is cached"
+
+    klass.clear_dependency_cache
+
+    refute start_dep_cached?(klass), "clear_dependency_cache should drop the start-dep cache entry"
+  end
+
+  # An unrelated class's prestart cache must survive a per-class clear.
+  def test_clear_dependency_cache_does_not_clear_other_classes
+    Taski::StaticAnalysis::StartDepAnalyzer.analyze(StartDepFixtures::SlowDepA)
+    Taski::StaticAnalysis::StartDepAnalyzer.analyze(StartDepFixtures::ParallelStartDepRoot)
+
+    StartDepFixtures::SlowDepA.clear_dependency_cache
+
+    assert start_dep_cached?(StartDepFixtures::ParallelStartDepRoot),
+      "clearing one class must not evict another class's prestart cache"
+  end
+
+  private
+
+  def start_dep_cached?(klass)
+    Taski::StaticAnalysis::StartDepAnalyzer.instance_variable_get(:@cache).key?(klass)
+  end
+
+  # Force DependencyGraph#cyclic_components to report a cycle for the duration of
+  # the block, so we can observe whether validation actually re-runs.
+  def with_cyclic_components
+    graph = Taski::StaticAnalysis::DependencyGraph
+    original = graph.instance_method(:cyclic_components)
+    graph.define_method(:cyclic_components) { [[Object]] }
+    yield
+  ensure
+    graph.define_method(:cyclic_components, original)
+  end
+end


### PR DESCRIPTION
## Problem

`Task.clear_dependency_cache` is the documented public hook for *"this task's code changed, re-analyze it."* But it only cleared `@dependencies_cache`, leaving two other per-class memos stale:

1. **`@circular_dependency_checked`** stayed `true`. `validate_no_circular_dependencies!` short-circuits on that flag (`return if @circular_dependency_checked`), so after a `clear_dependency_cache` a dependency change that **introduces a cycle is never re-checked** — the cycle ships undetected.
2. **The `StartDepAnalyzer` prestart cache** kept the old start-deps, so speculative prestart kept using a stale analysis (correctness of results is preserved by the pull model, but prestart is wrong).

## Fix

`clear_dependency_cache` now invalidates all three per-class memos:

```ruby
def clear_dependency_cache
  @dependencies_cache = nil
  @circular_dependency_checked = false
  StaticAnalysis::StartDepAnalyzer.clear_cache_for(self)
end
```

`StartDepAnalyzer.clear_cache_for(task_class)` is new and evicts **only** the given class (unlike the existing `clear_cache!`, which clears everything), so clearing one task does not throw away every other task's prestart analysis.

## Tests

`test/test_clear_dependency_cache.rb`:
- a newly-introduced cycle is caught after `clear_dependency_cache` (and is *not* caught without it — confirming the memo previously masked it)
- the class's prestart cache entry is dropped
- an unrelated class's prestart cache survives a per-class clear

`rake test` 716 runs / 0 failures, `rake standard` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)