### PR TITLE
Make Taski.args / Taski.env per-execution (fiber-local)

### DIFF
--- a/lib/taski.rb
+++ b/lib/taski.rb
@@ -160,8 +160,6 @@ module Taski
     end
   end
 
-  @args_monitor = Monitor.new
-  @env_monitor = Monitor.new
   @message_monitor = Monitor.new
   @logger_monitor = Monitor.new
 
@@ -178,15 +176,17 @@ module Taski
   end
 
   # Get the current runtime arguments
+  # Args/env are per-execution state held in fiber-local storage, so concurrent
+  # top-level runs on different threads never share or clobber each other.
   # @return [Args, nil] The current args or nil if no task is running
   def self.args
-    @args_monitor.synchronize { @args }
+    Thread.current[:taski_args]
   end
 
   # Get the current execution environment
   # @return [Env, nil] The current env or nil if no task is running
   def self.env
-    @env_monitor.synchronize { @env }
+    Thread.current[:taski_env]
   end
 
   # Output a message to the user without being captured by TaskOutputRouter.
@@ -210,22 +210,21 @@ module Taski
   # @api private
   # @return [Boolean] true if this call created the env, false if env already existed
   def self.start_env(root_task:)
-    @env_monitor.synchronize do
-      return false if @env
-      @env = Env.new(root_task: root_task)
-      true
-    end
+    return false if Thread.current[:taski_env]
+    Thread.current[:taski_env] = Env.new(root_task: root_task)
+    true
   end
 
   # Reset the execution environment (internal use only)
   # @api private
   def self.reset_env!
-    @env_monitor.synchronize { @env = nil }
+    Thread.current[:taski_env] = nil
   end
 
   # Execute a block with env lifecycle management.
-  # Creates env if it doesn't exist, and resets it only if this call created it.
-  # This prevents race conditions in concurrent execution.
+  # Creates env if it doesn't exist on this fiber, and resets it only if this
+  # call created it — so a nested execution reuses the outer env while
+  # independent (concurrent) executions each get their own.
   #
   # @param root_task [Class] The root task class
   # @yield The block to execute with env available
@@ -241,22 +240,21 @@ module Taski
   # @api private
   # @return [Boolean] true if this call created the args, false if args already existed
   def self.start_args(options:)
-    @args_monitor.synchronize do
-      return false if @args
-      @args = Args.new(options: options)
-      true
-    end
+    return false if Thread.current[:taski_args]
+    Thread.current[:taski_args] = Args.new(options: options)
+    true
   end
 
   # Reset the runtime arguments (internal use only)
   # @api private
   def self.reset_args!
-    @args_monitor.synchronize { @args = nil }
+    Thread.current[:taski_args] = nil
   end
 
   # Execute a block with args lifecycle management.
-  # Creates args if they don't exist, and resets them only if this call created them.
-  # This prevents race conditions in concurrent execution.
+  # Creates args if they don't exist on this fiber, and resets them only if this
+  # call created them — so a nested execution reuses the outer args while
+  # independent (concurrent) executions each get their own.
   #
   # @param options [Hash] User-defined options
   # @yield The block to execute with args available
@@ -338,6 +336,19 @@ module Taski
   # @api private
   def self.clear_current_registry
     Thread.current[:taski_current_registry] = nil
+  end
+
+  # Propagate an already-created Args/Env to the current fiber. Used by the
+  # worker pool to hand each worker the calling execution's args/env, since
+  # fiber-local storage does not cross the caller -> worker thread boundary.
+  # @api private
+  def self.set_current_args(args)
+    Thread.current[:taski_args] = args
+  end
+
+  # @api private
+  def self.set_current_env(env)
+    Thread.current[:taski_env] = env
   end
 end
 

--- a/lib/taski/execution/worker_pool.rb
+++ b/lib/taski/execution/worker_pool.rb
@@ -34,6 +34,11 @@ module Taski
         @execution_facade = execution_facade
         @worker_count = worker_count || Execution.default_worker_count
         @completion_queue = completion_queue
+        # Capture the calling execution's args/env now (on the caller fiber, where
+        # they are in scope) so each worker can re-establish them — fiber-local
+        # storage does not cross the caller -> worker thread boundary.
+        @run_args = Taski.args
+        @run_env = Taski.env
         @threads = []
         @thread_queues = []
         @next_thread_index = 0
@@ -313,6 +318,8 @@ module Taski
         Thread.current[:taski_current_phase] = :clean
         ExecutionFacade.current = @execution_facade
         Taski.set_current_registry(@registry)
+        Taski.set_current_args(@run_args)
+        Taski.set_current_env(@run_env)
       end
 
       def setup_run_thread_locals
@@ -320,6 +327,8 @@ module Taski
         Thread.current[:taski_current_phase] = :run
         ExecutionFacade.current = @execution_facade
         Taski.set_current_registry(@registry)
+        Taski.set_current_args(@run_args)
+        Taski.set_current_env(@run_env)
       end
 
       def teardown_thread_locals
@@ -327,6 +336,8 @@ module Taski
         Thread.current[:taski_current_phase] = nil
         ExecutionFacade.current = nil
         Taski.clear_current_registry
+        Taski.reset_args!
+        Taski.reset_env!
       end
 
       def task_duration_ms(task_class)

--- a/lib/taski/execution/worker_pool.rb
+++ b/lib/taski/execution/worker_pool.rb
@@ -197,8 +197,11 @@ module Taski
       end
 
       # Resume a parked Fiber from the thread queue.
-      # Restores fiber context before resuming since teardown_thread_locals
-      # cleared thread-local state when the fiber was parked.
+      # Re-establishes the execution context (registry/args/env) on the worker
+      # thread before resuming. A parked fiber keeps its own fiber-local state
+      # across the suspend (teardown runs on completion/failure, not on park), so
+      # this is what carries the execution's context onto whichever worker thread
+      # picks the fiber up.
       def resume_fiber(fiber, value, queue)
         resume_fiber_with_value(fiber, value, queue)
       end

--- a/test/fixtures/args_tasks.rb
+++ b/test/fixtures/args_tasks.rb
@@ -234,4 +234,24 @@ module ArgsFixtures
       @combined = "#{ExportedWithArgsDepTask.dep_greeting} + root"
     end
   end
+
+  # Concurrent-isolation probe. Blocks on a class-level barrier so two separate
+  # top-level executions overlap in their args lifecycle, then pushes the marker
+  # it observed into a class-level sink. Used to prove concurrent runs on
+  # different threads each see their own args rather than sharing one set.
+  class ConcurrentArgsTask < Taski::Task
+    exports :seen_marker
+
+    class << self
+      attr_accessor :barrier, :sink
+    end
+
+    def run
+      # Reach the barrier only after this execution's args are in scope, so both
+      # executions are live at the same time when the marker is read.
+      self.class.barrier&.call
+      @seen_marker = Taski.args[:marker]
+      self.class.sink&.push(@seen_marker)
+    end
+  end
 end

--- a/test/test_concurrent_args_isolation.rb
+++ b/test/test_concurrent_args_isolation.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "timeout"
+require_relative "fixtures/args_tasks"
+
+# Taski.args / Taski.env are per-execution state. Two concurrent top-level
+# Task.run / .value calls on different threads must each see their OWN args and
+# env — they must not share a single process-wide set (which would silently drop
+# the second caller's args).
+class TestConcurrentArgsIsolation < Minitest::Test
+  def setup
+    Taski::Task.reset! if defined?(Taski::Task)
+    ArgsFixtures::CapturedValues.clear
+  end
+
+  def teardown
+    ArgsFixtures::ConcurrentArgsTask.barrier = nil
+    ArgsFixtures::ConcurrentArgsTask.sink = nil
+  end
+
+  # A 2-party rendezvous: both callers block until both have entered the guarded
+  # region, guaranteeing their args lifecycles overlap in time.
+  def make_barrier(parties)
+    mutex = Mutex.new
+    cond = ConditionVariable.new
+    count = 0
+    lambda do
+      mutex.synchronize do
+        count += 1
+        cond.broadcast if count >= parties
+        cond.wait(mutex, 1) until count >= parties
+      end
+    end
+  end
+
+  # Caller-thread level: two threads each open their own with_args and must read
+  # back their own options, even while both are open simultaneously.
+  def test_with_args_is_isolated_between_threads
+    Timeout.timeout(10) do
+      barrier = make_barrier(2)
+      seen = {}
+      seen_mutex = Mutex.new
+
+      threads = %w[X Y].map do |id|
+        Thread.new do
+          Taski.send(:with_args, options: {id: id}) do
+            barrier.call # both threads are now inside their own with_args
+            seen_mutex.synchronize { seen[id] = Taski.args[:id] }
+          end
+        end
+      end
+      threads.each(&:join)
+
+      assert_equal({"X" => "X", "Y" => "Y"}, seen,
+        "each thread's with_args must be independent, not a shared singleton")
+    end
+  end
+
+  # Caller-thread level for env: same isolation guarantee for Taski.env.
+  def test_with_env_is_isolated_between_threads
+    Timeout.timeout(10) do
+      barrier = make_barrier(2)
+      seen = {}
+      seen_mutex = Mutex.new
+
+      threads = [ArgsFixtures::DepTask, ArgsFixtures::RootConsistencyTask].map do |root|
+        Thread.new do
+          Taski.send(:with_env, root_task: root) do
+            barrier.call
+            seen_mutex.synchronize { seen[root] = Taski.env.root_task }
+          end
+        end
+      end
+      threads.each(&:join)
+
+      assert_equal ArgsFixtures::DepTask, seen[ArgsFixtures::DepTask]
+      assert_equal ArgsFixtures::RootConsistencyTask, seen[ArgsFixtures::RootConsistencyTask]
+    end
+  end
+
+  # Full execution: two concurrent Task.run calls with different args, forced to
+  # overlap, must each have their worker see their own marker.
+  def test_concurrent_top_level_runs_see_their_own_args
+    Timeout.timeout(20) do
+      sink = Queue.new
+      ArgsFixtures::ConcurrentArgsTask.barrier = make_barrier(2)
+      ArgsFixtures::ConcurrentArgsTask.sink = sink
+
+      threads = %w[alpha bravo].map do |marker|
+        Thread.new do
+          ArgsFixtures::ConcurrentArgsTask.run(args: {marker: marker}, workers: 1)
+        end
+      end
+      threads.each { |t| t.join(15) }
+
+      seen = [sink.pop, sink.pop].sort
+      assert_equal %w[alpha bravo], seen,
+        "each concurrent execution's worker must observe its own args"
+    end
+  end
+end


### PR DESCRIPTION
## Bug

`Taski.@args` / `Taski.@env` were module-level singletons. `start_args` / `start_env` are first-wins guards (`return false if @args`), so two concurrent **top-level** `Task.run` / `.value` calls on different threads silently shared one set — the second caller's args/env were dropped (silent data corruption). The correct model is per-execution, exactly like `current_registry` (already thread/fiber-local).

## Fix

Move args/env into fiber-local storage (`Thread.current[:taski_args]` / `[:taski_env]`):

- `args` / `env` / `start_*` / `reset_*` now read/write fiber-local storage. `with_args` / `with_env` keep their **nesting** semantics *per fiber* — a nested execution reuses the outer args; independent (concurrent) executions each get their own.
- Fiber-local storage does **not** cross the caller → worker thread boundary, so `WorkerPool` captures the calling execution's args/env at construction (`@run_args` / `@run_env`) and re-establishes them in `setup_run_thread_locals` / `setup_clean_thread_locals`, clearing in `teardown_thread_locals` — the same propagation already used for the registry.
- The now-pointless `@args_monitor` / `@env_monitor` are removed.

This mirrors the existing `current_registry` propagation one-for-one, so it inherits the same fiber lifecycle guarantees (parked-then-resumed fibers, the clean phase, nested executions).

## Tests

`test/test_concurrent_args_isolation.rb`:
- caller-thread isolation for both **args** and **env** (two threads, a barrier forcing their lifecycles to overlap)
- a full two-thread execution where each worker must observe its own args

All three reproduce the bug on the old code (`{"Y"=>"X","X"=>"X"}`; both workers saw `"alpha"`) and pass after the fix. `rake test` 716 / 0, `rake standard` clean.

An adversarial multi-agent review (4 angles → per-finding verification) found no surviving functional defect; its one in-scope nit — a misleading `resume_fiber` comment about parked-fiber teardown — is fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed concurrent execution isolation to ensure parallel tasks maintain separate argument and environment contexts
  * Worker pools now properly capture and restore execution state across thread boundaries

* **Tests**
  * Added comprehensive tests validating concurrent isolation of task arguments and environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->