### PR TITLE
Make silent-degradation paths observable in logs

### DIFF
--- a/lib/taski/logging.rb
+++ b/lib/taski/logging.rb
@@ -46,6 +46,10 @@ module Taski
       OUTPUT_ROUTER_DRAIN_PIPE = "output_router.drain_pipe"
       OUTPUT_ROUTER_STORE_LINES = "output_router.store_lines"
       OBSERVER_ERROR = "observer.error"
+
+      # Diagnostics for silent-degradation paths
+      ANALYSIS_ERROR = "analysis.start_dep_failed" # prestart analysis hit an unexpected error
+      TEMPLATE_ERROR = "template.render_error"     # a theme's Liquid template failed to render
     end
 
     # Log severity levels matching Ruby Logger

--- a/lib/taski/progress/layout/base.rb
+++ b/lib/taski/progress/layout/base.rb
@@ -191,7 +191,7 @@ module Taski
 
         # Log a template failure and return the empty-string fallback.
         def warn_and_blank(error)
-          Taski::Logging.warn(Taski::Logging::Events::OBSERVER_ERROR, error_message: "template render failed: #{error.message}")
+          Taski::Logging.warn(Taski::Logging::Events::TEMPLATE_ERROR, error_message: "template render failed: #{error.message}")
           ""
         end
 

--- a/lib/taski/static_analysis/start_dep_analyzer.rb
+++ b/lib/taski/static_analysis/start_dep_analyzer.rb
@@ -83,11 +83,20 @@ module Taski
         start_deps = all_dep_classes - unsafe_classes
         sync_deps = unsafe_classes
         AnalysisResult.new(start_deps: start_deps, sync_deps: sync_deps)
-      rescue
+      rescue => e
         # Prestart analysis is a pure performance optimization. If anything goes
         # wrong (missing/unreadable source file, unexpected AST shape, constant
         # resolution failure, ...) degrade to no prestart — tasks still execute
         # correctly via lazy Fiber pull. This must never crash a worker thread.
+        # Log it, though: the happy path returns EMPTY_RESULT for known-unanalyzable
+        # code without raising, so reaching here means something unexpected that a
+        # user debugging missing prestart should be able to see.
+        Taski::Logging.warn(
+          Taski::Logging::Events::ANALYSIS_ERROR,
+          task: (@task_class.name if @task_class.respond_to?(:name)),
+          error_class: e.class.name,
+          error_message: e.message
+        )
         EMPTY_RESULT
       end
 

--- a/test/test_layout_base.rb
+++ b/test/test_layout_base.rb
@@ -58,6 +58,23 @@ class TestLayoutBase < Minitest::Test
     refute_includes result, "Liquid error"
   end
 
+  # A template (theme) failure must log a distinct TEMPLATE_ERROR event rather
+  # than reusing OBSERVER_ERROR, so a broken theme can be told apart from an
+  # observer-callback crash when filtering logs.
+  def test_template_failure_logs_template_error_not_observer_error
+    require "logger"
+    log_output = StringIO.new
+    original_logger = Taski.logger
+    Taski.logger = Logger.new(log_output)
+
+    @layout.send(:render_template_string, "{% if true %}never closed")
+
+    assert_match(/template\.render_error/, log_output.string)
+    refute_match(/observer\.error/, log_output.string)
+  ensure
+    Taski.logger = original_logger
+  end
+
   # === Inheritance tests ===
 
   def test_inherits_from_task_observer

--- a/test/test_start_dep_analyzer.rb
+++ b/test/test_start_dep_analyzer.rb
@@ -8,6 +8,32 @@ class TestStartDepAnalyzer < Minitest::Test
     Taski::StaticAnalysis::StartDepAnalyzer.clear_cache!
   end
 
+  # Prestart analysis degrades to "no prestart" on any internal error, but the
+  # error must be logged (not swallowed silently) so a real analysis bug is
+  # diagnosable rather than invisible.
+  def test_analyze_logs_when_analysis_unexpectedly_raises
+    require "logger"
+    require "stringio"
+    log_output = StringIO.new
+    original_logger = Taski.logger
+    Taski.logger = Logger.new(log_output)
+    original_parse = Prism.method(:parse_file)
+
+    result = begin
+      Prism.define_singleton_method(:parse_file) { |*| raise "boom in prism" }
+      Taski::StaticAnalysis::StartDepAnalyzer.analyze(StartDepAnalyzerFixtures::LeafTask)
+    ensure
+      Prism.define_singleton_method(:parse_file, original_parse)
+      Taski.logger = original_logger
+    end
+
+    # Still degrades gracefully (tasks run via the lazy pull model)...
+    assert_equal Taski::StaticAnalysis::StartDepAnalyzer::EMPTY_RESULT, result
+    # ...but the unexpected failure is surfaced in the log.
+    assert_match(/analysis\.start_dep_failed/, log_output.string)
+    assert_match(/boom in prism/, log_output.string)
+  end
+
   def test_local_variable_assignment_dep
     result = Taski::StaticAnalysis::StartDepAnalyzer.analyze(
       StartDepAnalyzerFixtures::LocalVarAssignment


### PR DESCRIPTION
## Problem

Two paths degrade gracefully but swallow the cause, so a real bug is invisible:

1. **`StartDepAnalyzer.analyze`** rescues every error and returns `EMPTY_RESULT` with **no log**. The happy path already returns `EMPTY_RESULT` for known-unanalyzable code *without* raising, so reaching the rescue means something genuinely unexpected (unreadable source, surprising AST shape, constant-resolution failure). A user wondering why prestart never happens has nothing to go on.
2. **A theme's Liquid template failure** logged `OBSERVER_ERROR` — the same event used for observer-callback crashes in `ExecutionFacade`. The two are different failures (a broken theme vs. a crashing observer) and conflating them makes log filtering/debugging harder.

## Change

- Add `Logging::Events::ANALYSIS_ERROR` (`"analysis.start_dep_failed"`) and log it (warn level, with error class + message + task) in the analyzer rescue before degrading.
- Add `Logging::Events::TEMPLATE_ERROR` (`"template.render_error"`) and use it in `warn_and_blank` instead of `OBSERVER_ERROR`.

Both stay non-fatal and warn-level; the default nil logger remains silent, so this only surfaces when the user has opted into logging.

## Tests

- `test_start_dep_analyzer.rb`: forcing an analyzer failure now logs `analysis.start_dep_failed` (and still returns `EMPTY_RESULT`).
- `test_layout_base.rb`: a malformed template logs `template.render_error` and **not** `observer.error`.

`rake test` 715 / 0, `rake standard` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)