### PR TITLE
Remove dead Scheduler#next_ready_tasks and ready_to_execute?

### DIFF
--- a/lib/taski/execution/scheduler.rb
+++ b/lib/taski/execution/scheduler.rb
@@ -16,17 +16,17 @@ module Taski
     #
     # - Load pre-built dependency graph from Executor
     # - Track task states: pending, running, completed
-    # - Determine which tasks are ready to execute (all dependencies completed)
-    # - Provide next_ready_tasks for the Executor's event loop
     # - Build reverse dependency graph for clean operations
     # - Track clean states independently from run states
     # - Provide next_ready_clean_tasks for reverse dependency order execution
+    #
+    # Run-phase ordering is NOT scheduled here — tasks pull their dependencies on
+    # demand via the Fiber protocol (FiberProtocol::NeedDep) in the WorkerPool.
     #
     # == API
     #
     # Run operations:
     # - {#load_graph} - Load pre-built dependency graph
-    # - {#next_ready_tasks} - Get tasks ready for execution
     # - {#mark_running} - Mark task as sent to worker pool
     # - {#mark_completed} - Mark task as finished
     # - {#finished?} - Check if task is completed
@@ -94,22 +94,7 @@ module Taski
         end
       end
 
-      # Get all tasks that are ready to execute.
-      # A task is ready when it is pending and all its dependencies are completed.
-      #
-      # @return [Array<Class>] Array of task classes ready for execution
-      def next_ready_tasks
-        ready = []
-        @task_states.each_key do |task_class|
-          next unless @task_states[task_class] == STATE_PENDING
-          next unless ready_to_execute?(task_class)
-          ready << task_class
-        end
-        ready
-      end
-
-      # Mark a task as running (sent to worker pool).
-      # Prevents the task from being selected again by next_ready_tasks.
+      # Mark a task as running (driven as a Fiber on the worker pool).
       #
       # @param task_class [Class] The task class to mark
       def mark_running(task_class)
@@ -304,12 +289,6 @@ module Taski
       end
 
       private
-
-      # Check if a task is ready to execute (all dependencies completed).
-      def ready_to_execute?(task_class)
-        task_deps = @dependencies[task_class] || Set.new
-        task_deps.subset?(@finished_tasks)
-      end
 
       # Check if a task is ready to clean (all reverse dependencies completed).
       def ready_to_clean?(task_class)

--- a/test/test_scheduler.rb
+++ b/test/test_scheduler.rb
@@ -523,10 +523,11 @@ class TestScheduler < Minitest::Test
   end
 
   # mark_skipped only transitions from pending, so a skipped task cannot be
-  # skipped again. (Run-phase ordering, including "a skipped task is never
-  # enqueued to run", is the Executor's responsibility — the Scheduler is only
-  # accessed from the Executor's serialized event loop and does not police
-  # mark_running's caller.)
+  # skipped again. (The Scheduler does not police run-phase ordering:
+  # mark_running has no terminal-state guard, and under the Fiber pull model a
+  # task marked skipped can still be started later by a still-running requester
+  # via NeedDep — :skipped is advisory bookkeeping for reporting, not an
+  # execution barrier.)
   def test_skipped_task_cannot_be_re_skipped
     task = Class.new(Taski::Task) do
       exports :value

--- a/test/test_scheduler.rb
+++ b/test/test_scheduler.rb
@@ -522,7 +522,12 @@ class TestScheduler < Minitest::Test
     assert_equal 1, scheduler.skipped_count
   end
 
-  def test_skipped_is_terminal_cannot_transition_to_running
+  # mark_skipped only transitions from pending, so a skipped task cannot be
+  # skipped again. (Run-phase ordering, including "a skipped task is never
+  # enqueued to run", is the Executor's responsibility — the Scheduler is only
+  # accessed from the Executor's serialized event loop and does not police
+  # mark_running's caller.)
+  def test_skipped_task_cannot_be_re_skipped
     task = Class.new(Taski::Task) do
       exports :value
       def run = @value = "test"
@@ -534,7 +539,6 @@ class TestScheduler < Minitest::Test
 
     scheduler.mark_skipped(task)
 
-    # A skipped task is terminal: it cannot be skipped (or transitioned) again.
     refute scheduler.mark_skipped(task), "cannot skip an already-skipped task"
   end
 

--- a/test/test_scheduler.rb
+++ b/test/test_scheduler.rb
@@ -43,44 +43,6 @@ class TestScheduler < Minitest::Test
     assert_equal 2, scheduler.task_count
   end
 
-  def test_next_ready_tasks_returns_pending_tasks
-    task = Class.new(Taski::Task) do
-      exports :value
-      def run
-        @value = "test"
-      end
-    end
-
-    graph = Taski::StaticAnalysis::DependencyGraph.new.build_from_cached(task)
-    scheduler = Taski::Execution::Scheduler.new
-    scheduler.load_graph(graph, task)
-
-    ready = scheduler.next_ready_tasks
-
-    assert_includes ready, task
-  end
-
-  def test_mark_running_prevents_re_selection
-    task = Class.new(Taski::Task) do
-      exports :value
-      def run
-        @value = "test"
-      end
-    end
-
-    graph = Taski::StaticAnalysis::DependencyGraph.new.build_from_cached(task)
-    scheduler = Taski::Execution::Scheduler.new
-    scheduler.load_graph(graph, task)
-
-    ready1 = scheduler.next_ready_tasks
-    assert_includes ready1, task
-
-    scheduler.mark_running(task)
-
-    ready2 = scheduler.next_ready_tasks
-    refute_includes ready2, task
-  end
-
   def test_mark_completed
     task = Class.new(Taski::Task) do
       exports :value
@@ -360,8 +322,6 @@ class TestScheduler < Minitest::Test
     assert_equal 1, scheduler.skipped_count
     # No longer pending
     refute_includes scheduler.never_started_task_classes, task
-    # Not ready for execution
-    assert_empty scheduler.next_ready_tasks
   end
 
   def test_mark_skipped_returns_false_from_running
@@ -518,12 +478,10 @@ class TestScheduler < Minitest::Test
     scheduler.load_graph(graph, task)
 
     # pending
-    assert_includes scheduler.next_ready_tasks, task
     refute scheduler.finished?(task)
 
     # running
     scheduler.mark_running(task)
-    refute_includes scheduler.next_ready_tasks, task
     assert scheduler.running_tasks?
 
     # completed
@@ -562,7 +520,6 @@ class TestScheduler < Minitest::Test
 
     assert scheduler.mark_skipped(task)
     assert_equal 1, scheduler.skipped_count
-    assert_empty scheduler.next_ready_tasks
   end
 
   def test_skipped_is_terminal_cannot_transition_to_running
@@ -577,10 +534,8 @@ class TestScheduler < Minitest::Test
 
     scheduler.mark_skipped(task)
 
-    # mark_running overwrites state but skipped task won't be in next_ready_tasks
-    # and mark_skipped won't transition again
+    # A skipped task is terminal: it cannot be skipped (or transitioned) again.
     refute scheduler.mark_skipped(task), "cannot skip an already-skipped task"
-    refute_includes scheduler.next_ready_tasks, task, "skipped task should not appear as ready"
   end
 
   def test_clean_phase_pending_to_running_to_completed


### PR DESCRIPTION
## What

`Scheduler#next_ready_tasks` and its sole caller `ready_to_execute?` are dead in production. The Executor drives the **run** phase through the Fiber pull model (`FiberProtocol::NeedDep` — tasks request dependencies on demand in the WorkerPool) and only uses the Scheduler for state tracking and the **clean** phase (`next_ready_clean_tasks`). The run-phase `next_ready_tasks` was never invoked — and the class doc even advertised it "for the Executor's event loop", which the Executor does not use.

## Change

- Delete `next_ready_tasks` and `ready_to_execute?`.
- Delete their two dedicated unit tests.
- Drop the `next_ready_tasks` probes from four state-machine tests; they still assert the live transitions via `finished?` / `running_tasks?` / `skipped_count` / `mark_skipped`.
- Update the class doc to state run-phase ordering is pull-based, not scheduled.

Verified the removal doesn't orphan scheduler state (`@dependencies` and `@finished_tasks` remain used by other methods).

`rake test` 733 / 0, `rake standard` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed scheduling to resolve task dependencies on-demand rather than precomputing run-order; run-phase orchestration is now driven by workers.
* **Tests**
  * Updated scheduler tests to reflect on-demand dependency resolution and removed expectations tied to the former precomputed run-order behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->