### PR TITLE
Make proxy W1/W2 walls explicit + add regression tests

### DIFF
--- a/lib/taski/static_analysis/start_dep_analyzer.rb
+++ b/lib/taski/static_analysis/start_dep_analyzer.rb
@@ -201,8 +201,26 @@ module Taski
       # Returns a Set of dep classes whose proxy variables are used unsafely.
       # A proxy variable is a local variable assigned from a Taski::Task dep call
       # (e.g., `a = Dep.value`). If such a variable is later used in an unsafe
-      # context (as argument, condition, array element, etc.), the dep class is
-      # added to sync_dep_classes so it will be resolved synchronously.
+      # context, the dep class is demoted to sync (resolved synchronously to the
+      # real value) instead of handed back as a lazy proxy.
+      #
+      # A proxy is "unsafe" wherever the real value is consumed by an operation
+      # that bypasses TaskProxy's method dispatch:
+      #   W1 (truthiness) — if/unless/while/until/ternary predicate, && / ||
+      #      operands: `if proxy` / `proxy && x` test nil/false at the C level,
+      #      and a proxy is always truthy.
+      #   W2 (=== / pattern) — a `case` subject: `when SomeClass` / `in SomeClass`
+      #      checks the proxy's REAL class (TaskProxy), not the wrapped value.
+      #   Arguments / array elements — `foo(proxy)` / `[proxy]`: the callee may
+      #      compare the proxy with `==`/`include?`/`===`, and String#==, Array#==
+      #      (and any C-level == without a coercion fallback) silently return
+      #      false against a proxy. We cannot tell a safe dispatch-arg from an
+      #      unsafe comparison-arg statically, so arguments/elements stay sync.
+      #
+      # IMPORTANT: the argument/array-element demotion is load-bearing, NOT merely
+      # conservative — dropping it makes `["x"].include?(Dep.value)` and similar
+      # silently wrong. Receiver use (`proxy.foo`) and string interpolation are
+      # the only positions proven proxy-safe.
       def detect_unsafe_proxy_usage(body_node)
         proxy_vars = build_proxy_var_map(body_node)
 
@@ -299,6 +317,30 @@ module Taski
         when Prism::WhileNode, Prism::UntilNode
           check_predicate_unsafe(node.predicate, proxy_vars, unsafe_classes)
           scan_for_unsafe_usage(node.statements, proxy_vars, unsafe_classes) if node.statements
+
+        when Prism::AndNode, Prism::OrNode
+          # W1 wall: && / || test their operands for truthiness — a C-level test
+          # that bypasses the proxy (a live proxy is always truthy). A bare proxy
+          # operand must be resolved synchronously.
+          [node.left, node.right].each do |operand|
+            if proxy_var_read?(operand, proxy_vars)
+              unsafe_classes.add(proxy_vars[predicate_key(operand)])
+            else
+              scan_for_unsafe_usage(operand, proxy_vars, unsafe_classes)
+            end
+          end
+
+        when Prism::CaseNode, Prism::CaseMatchNode
+          # W2 wall: the case subject is === / pattern matched, which inspects the
+          # real class and bypasses the proxy. A bare proxy subject must be
+          # resolved synchronously.
+          if proxy_var_read?(node.predicate, proxy_vars)
+            unsafe_classes.add(proxy_vars[predicate_key(node.predicate)])
+          elsif node.predicate
+            scan_for_unsafe_usage(node.predicate, proxy_vars, unsafe_classes)
+          end
+          node.conditions.each { |cond| scan_for_unsafe_usage(cond, proxy_vars, unsafe_classes) }
+          scan_for_unsafe_usage(node.else_clause, proxy_vars, unsafe_classes) if node.else_clause
 
         when Prism::InterpolatedStringNode
           node.parts.each do |part|

--- a/test/fixtures/start_dep_analyzer_tasks.rb
+++ b/test/fixtures/start_dep_analyzer_tasks.rb
@@ -444,4 +444,16 @@ module StartDepAnalyzerFixtures
       @value = true && mid && "c" # standard:disable Lint/LiteralAsCondition
     end
   end
+
+  # NOT a wall: `!proxy` parses as a method call (`!`) with the proxy as the
+  # RECEIVER, which TaskProxy#! resolves. So the dep stays a start_dep (proxy)
+  # and `!false` is computed correctly — guards against wrongly demoting `!`.
+  class NegationSafe < Taski::Task
+    exports :value
+
+    def run
+      flag = FalseLeaf.value
+      @value = !flag
+    end
+  end
 end

--- a/test/fixtures/start_dep_analyzer_tasks.rb
+++ b/test/fixtures/start_dep_analyzer_tasks.rb
@@ -336,4 +336,112 @@ module StartDepAnalyzerFixtures
       @flag = [1, 2].include?(@value) # exported ivar used as argument → unsafe
     end
   end
+
+  # === W1/W2 wall fixtures ===
+  #
+  # The irreducible C-level walls where a live proxy silently misbehaves:
+  #   W1 truthiness — if/unless/while/until/ternary predicate, && / || operands
+  #   W2 === match  — case/when subject, case/in pattern subject
+  # A proxy reaching any of these MUST be demoted to sync (resolved to the real
+  # value). These fixtures pin that: both the classification (dep in sync_deps)
+  # and the runtime result (no silent-wrong-result).
+
+  # Leaf returning a falsy value, so &&/||/ternary leaks are observable.
+  class FalseLeaf < Taski::Task
+    exports :value
+
+    def run
+      @value = false
+    end
+  end
+
+  # Leaf returning nil, for || fallback checks.
+  class NilLeaf < Taski::Task
+    exports :value
+
+    def run
+      @value = nil
+    end
+  end
+
+  # W2: proxy as a `case ... when` subject (=== type match bypasses the proxy).
+  class CaseWhenSubject < Taski::Task
+    exports :value
+
+    def run
+      kind = LeafTask.value
+      @value = case kind
+      when String then "matched-String"
+      else "no-match"
+      end
+    end
+  end
+
+  # W2: proxy as a `case ... in` (pattern match) subject.
+  class CaseInSubject < Taski::Task
+    exports :value
+
+    def run
+      kind = LeafTask.value
+      @value = case kind
+      in String then "matched-String"
+      else "no-match"
+      end
+    end
+  end
+
+  # W1: proxy as the left operand of && (truthiness short-circuit).
+  class AndOperand < Taski::Task
+    exports :value
+
+    def run
+      flag = FalseLeaf.value
+      @value = flag && "yes"
+    end
+  end
+
+  # W1: proxy as the left operand of ||.
+  class OrOperand < Taski::Task
+    exports :value
+
+    def run
+      flag = NilLeaf.value
+      @value = flag || "fallback"
+    end
+  end
+
+  # W1: proxy as a ternary condition.
+  class TernaryCondition < Taski::Task
+    exports :value
+
+    def run
+      x = FalseLeaf.value
+      @value = x ? "then-branch" : "else-branch"
+    end
+  end
+
+  # W1 regression: proxy as the RIGHT operand of && inside an if-predicate.
+  # (The naive "flag the left operand only" rule would miss this.)
+  class IfWithNestedAnd < Taski::Task
+    exports :value
+
+    def run
+      flag = FalseLeaf.value
+      @value = if true && flag # standard:disable Lint/LiteralAsCondition
+        "then-branch"
+      else
+        "else-branch"
+      end
+    end
+  end
+
+  # W1 regression: proxy as the MIDDLE operand of a chained &&.
+  class ChainedAndMiddle < Taski::Task
+    exports :value
+
+    def run
+      mid = FalseLeaf.value
+      @value = true && mid && "c" # standard:disable Lint/LiteralAsCondition
+    end
+  end
 end

--- a/test/test_start_dep_analyzer.rb
+++ b/test/test_start_dep_analyzer.rb
@@ -436,4 +436,18 @@ class TestStartDepAnalyzer < Minitest::Test
       assert_equal false, StartDepAnalyzerFixtures::ChainedAndMiddle.value
     end
   end
+
+  # `!proxy` is NOT a wall: it is a method call on the proxy (receiver), which
+  # TaskProxy resolves — so the dep stays a start_dep AND `!false` is correct.
+  def test_negation_is_not_a_wall
+    result = Taski::StaticAnalysis::StartDepAnalyzer.analyze(
+      StartDepAnalyzerFixtures::NegationSafe
+    )
+    assert_includes result.start_deps, StartDepAnalyzerFixtures::FalseLeaf
+    assert_empty result.sync_deps
+
+    Timeout.timeout(15) do
+      assert_equal true, StartDepAnalyzerFixtures::NegationSafe.value
+    end
+  end
 end

--- a/test/test_start_dep_analyzer.rb
+++ b/test/test_start_dep_analyzer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "timeout"
 require_relative "fixtures/start_dep_analyzer_tasks"
 
 class TestStartDepAnalyzer < Minitest::Test
@@ -391,5 +392,48 @@ class TestStartDepAnalyzer < Minitest::Test
     # @data used as argument → unsafe
     assert_includes result.sync_deps, StartDepAnalyzerFixtures::LeafTask
     refute_includes result.start_deps, StartDepAnalyzerFixtures::LeafTask
+  end
+
+  # ========================================
+  # W1/W2 walls: proxy used in a truthiness (W1) or === (W2) position MUST be
+  # demoted to sync, or it silently misbehaves (truthiness/=== bypass the proxy
+  # at the C level). Classification + end-to-end runtime-result guards.
+  # ========================================
+
+  # --- classification: the dep is demoted to sync, never a start_dep proxy ---
+
+  {
+    test_wall_case_when_subject: :CaseWhenSubject,
+    test_wall_case_in_subject: :CaseInSubject,
+    test_wall_and_left_operand: :AndOperand,
+    test_wall_or_left_operand: :OrOperand,
+    test_wall_ternary_condition: :TernaryCondition,
+    test_wall_if_with_nested_and: :IfWithNestedAnd,
+    test_wall_chained_and_middle: :ChainedAndMiddle
+  }.each do |test_name, fixture|
+    define_method(test_name) do
+      result = Taski::StaticAnalysis::StartDepAnalyzer.analyze(
+        StartDepAnalyzerFixtures.const_get(fixture)
+      )
+      dep = result.sync_deps.first || result.start_deps.first
+      refute_nil dep, "#{fixture}: expected a dependency to be analyzed"
+      assert_empty result.start_deps,
+        "#{fixture}: a proxy at a W1/W2 wall must be sync, never a start_dep"
+      refute_empty result.sync_deps, "#{fixture}: the wall dep must be in sync_deps"
+    end
+  end
+
+  # --- runtime: executing the task returns the correct value (no silent leak) ---
+
+  def test_wall_runtime_results_have_no_silent_leak
+    Timeout.timeout(15) do
+      assert_equal "matched-String", StartDepAnalyzerFixtures::CaseWhenSubject.value
+      assert_equal "matched-String", StartDepAnalyzerFixtures::CaseInSubject.value
+      assert_equal false, StartDepAnalyzerFixtures::AndOperand.value
+      assert_equal "fallback", StartDepAnalyzerFixtures::OrOperand.value
+      assert_equal "else-branch", StartDepAnalyzerFixtures::TernaryCondition.value
+      assert_equal "else-branch", StartDepAnalyzerFixtures::IfWithNestedAnd.value
+      assert_equal false, StartDepAnalyzerFixtures::ChainedAndMiddle.value
+    end
   end
 end


### PR DESCRIPTION
## Background

`StartDepAnalyzer` decides which dependencies to speculatively **prestart as a lazy `TaskProxy`** (overlap) vs **resolve synchronously** (block). A proxy is demoted to sync wherever the real value would be consumed by an operation that bypasses the proxy's `method_missing` dispatch.

This PR came out of investigating whether that phase-2 analysis could be simplified. The investigation found it **cannot** safely — and surfaced two gaps worth fixing without changing behavior.

## What was wrong

1. **Two walls had no dedicated handler and no tests.** `&&`/`||` operands (W1 truthiness) and `case` subjects (W2 `===`) were only demoted *incidentally* by the generic catch-all recurse + bare-read arm. Correct on `master`, but untested and fragile to any future refactor of the scan.
2. **The "just drop the argument/array demotion for more overlap" idea is unsafe.** A probe of the real proxy semantics:

   ```
   [1,2].include?(proxy(1))      => true   (numeric == has a coercion fallback → forces)
   %w[a b].include?(proxy("a"))  => false  ← LEAK (String#== returns false vs a proxy)
   [1,2] == proxy([1,2])         => false  ← LEAK (Array#==)
   ```

   `["x"].include?(Dep.value)` would silently return wrong results if the proxy were prestarted. Static analysis can't tell a safe dispatch-arg from an unsafe comparison-arg, so the argument/array demotion is **load-bearing, not conservative**.

## Change (no behavior change)

- Add explicit `Prism::AndNode/OrNode` and `CaseNode/CaseMatchNode` arms — behavior-identical to the prior catch-all coverage, but they state the intent (these are the W1/W2 walls).
- Add regression fixtures + tests for every wall: `case/when`, `case/in`, `&&`, `||`, ternary, and the two nested cases a naive "flag the left operand only" rule would miss (`if true && flag`, `true && mid && "c"`). Both the **classification** (dep in `sync_deps`) and the **end-to-end runtime result** are asserted.
- Document the W1/W2 model and the load-bearing role of the argument/array demotion on `detect_unsafe_proxy_usage`.

`rake test` 743 / 0, `rake standard` clean.

Follow-up (separate PR): a prestart inspection API (`Task.prestart_plan` / debug-mode `tree` annotation) so the heuristic is observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced detection of unsafe dependency proxy usage in logical operators (`&&`, `||`) and case/pattern matching statements.
  * Improved handling of truthiness predicates and conditional contexts to ensure dependencies resolve correctly.

* **Tests**
  * Added comprehensive test coverage for unsafe proxy usage scenarios including ternary conditions, nested conditionals, and chained logical operations.
  * Added runtime validation tests to prevent silent proxy bypass issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->