### PR TITLE
Never prestart deps referenced only outside the phase-1 prefix

### DIFF
--- a/lib/taski/static_analysis/start_dep_analyzer.rb
+++ b/lib/taski/static_analysis/start_dep_analyzer.rb
@@ -92,7 +92,14 @@ module Taski
         unsafe_classes = detect_unsafe_proxy_usage(run_node.body)
         all_dep_classes = Set.new(@deps.map(&:klass))
         start_deps = all_dep_classes - unsafe_classes
-        sync_deps = unsafe_classes
+        # Intersect with the phase-1 prefix deps: the unsafe-usage scan covers the
+        # WHOLE body (including never-taken branches and post-return code), but
+        # only prefix deps — the ones sequential semantics are certain to read —
+        # may be speculatively dispatched. Without this, a dep referenced only in
+        # a dead branch would be prestarted (and its failure would fail a run that
+        # sequential execution completes). Out-of-prefix deps simply resolve
+        # lazily at their actual read site.
+        sync_deps = unsafe_classes & all_dep_classes
         AnalysisResult.new(start_deps: start_deps, sync_deps: sync_deps, stopped_at: stopped_at_info)
       rescue => e
         # Prestart analysis is a pure performance optimization. If anything goes

--- a/test/fixtures/dead_branch_tasks.rb
+++ b/test/fixtures/dead_branch_tasks.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "taski"
+
+# Fixtures for the dead-branch prestart regression: a dep that is referenced
+# ONLY inside a never-taken branch (and used "unsafely" there, so phase-2's
+# whole-body scan flags it) must NOT be speculatively executed — sequential
+# semantics never reach its read.
+module DeadBranchFixtures
+  class Leaf < Taski::Task
+    exports :value
+
+    def run
+      @value = "leaf"
+    end
+  end
+
+  # Records whether it ever executed, so tests can assert it did NOT.
+  class DeadProbe < Taski::Task
+    exports :value
+
+    class << self
+      attr_accessor :ran
+    end
+
+    def run
+      self.class.ran = true
+      @value = "dead-probe"
+    end
+  end
+
+  # Raises if it ever executes — a run that never reads it must still succeed.
+  class RaisingDead < Taski::Task
+    exports :value
+
+    def run
+      raise "executed a dep that is only referenced in a dead branch"
+    end
+  end
+
+  # The branch condition is false at runtime ("leaf" is not empty), so the
+  # branch body — where DeadProbe is read and passed as an argument (an
+  # "unsafe" use that phase-2 flags) — never executes.
+  class DeadBranchRoot < Taski::Task
+    exports :value
+
+    def run
+      a = Leaf.value
+      if a.to_s.empty?
+        x = DeadProbe.value
+        @flag = [1].include?(x)
+      end
+      @value = "root: #{a}"
+    end
+  end
+
+  # Same shape, but the dead-branch dep raises when executed. Sequential
+  # semantics succeed (the branch is never taken), so the run must succeed.
+  class DeadBranchRaisingRoot < Taski::Task
+    exports :value
+
+    def run
+      a = Leaf.value
+      if a.to_s.empty?
+        x = RaisingDead.value
+        @flag = [1].include?(x)
+      end
+      @value = "ok: #{a}"
+    end
+  end
+end

--- a/test/test_dead_branch_prestart.rb
+++ b/test/test_dead_branch_prestart.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "timeout"
+require_relative "fixtures/dead_branch_tasks"
+
+# Prestart must only speculate on deps from the leading straight-line prefix of
+# run — deps that sequential semantics are CERTAIN to read. A dep referenced
+# only inside a never-taken branch must not be dispatched: phase-2's
+# unsafe-usage scan covers the whole body, and its output must not widen the
+# prestart set beyond the phase-1 prefix.
+class TestDeadBranchPrestart < Minitest::Test
+  def setup
+    Taski::Task.reset! if defined?(Taski::Task)
+    Taski::StaticAnalysis::StartDepAnalyzer.clear_cache!
+    DeadBranchFixtures::DeadProbe.ran = false
+  end
+
+  # Classification: the dead-branch dep must not appear in sync_deps (which
+  # feeds the prestart dispatch union) — only prefix deps are prestartable.
+  def test_dead_branch_dep_is_not_in_the_prestart_sets
+    result = Taski::StaticAnalysis::StartDepAnalyzer.analyze(
+      DeadBranchFixtures::DeadBranchRoot
+    )
+
+    assert_includes result.start_deps, DeadBranchFixtures::Leaf
+    refute_includes result.sync_deps, DeadBranchFixtures::DeadProbe,
+      "a dep referenced only in a dead branch must not be dispatched via sync_deps"
+    refute_includes result.start_deps, DeadBranchFixtures::DeadProbe
+  end
+
+  # Runtime: the dead-branch dep must never execute.
+  def test_dead_branch_dep_does_not_execute
+    Timeout.timeout(15) do
+      assert_equal "root: leaf", DeadBranchFixtures::DeadBranchRoot.value
+    end
+
+    refute DeadBranchFixtures::DeadProbe.ran,
+      "a dep whose only reference is inside a never-taken branch was executed"
+  end
+
+  # Runtime: a raising dead-branch dep must not fail a run that sequential
+  # semantics would complete successfully.
+  def test_raising_dead_branch_dep_does_not_fail_the_run
+    Timeout.timeout(15) do
+      assert_equal "ok: leaf", DeadBranchFixtures::DeadBranchRaisingRoot.value
+    end
+  end
+end


### PR DESCRIPTION
## Bug

Phase-1 (the prestart candidate scan) stops at the leading straight-line prefix of `run` — by design, so speculation only runs deps that sequential semantics are **certain** to read. But phase-2's unsafe-usage scan covers the **whole body** (including never-taken branches and post-`return` code), and its output (`sync_deps`) fed the prestart dispatch union (`start_deps | sync_deps`) **without being intersected against the prefix**.

Consequence, reproduced end-to-end:

```ruby
def run
  a = Leaf.value
  if a.to_s.empty?          # never true
    x = DeadDep.value       # read only in the dead branch
    @flag = [1].include?(x) # "unsafe" arg use -> phase-2 flags DeadDep
  end
  @value = "ok: #{a}"
end
```

`DeadDep` lands in `sync_deps` → prestart dispatches it → **it executes on every run** even though its read is never reached. Worse: if `DeadDep` raises, `raise_if_any_failures` fails the whole run with `AggregateError` — a run that sequential execution completes successfully.

## Fix

```ruby
sync_deps = unsafe_classes & all_dep_classes
```

Only phase-1 prefix deps may be speculated. Out-of-prefix deps resolve lazily at their actual read site (`NeedDep` → `DepStarting`) — exactly the sequential contract. The load-bearing argument demotion (`String#==`/`include?` proxy leak) is unaffected: it governs *how prefix deps resolve*, and prefix deps used unsafely remain in the intersection (all existing demotion tests pass unchanged).

Note: a dep on the straight line *past* the phase-1 cutoff also stops being dispatched early (it previously was, when flagged unsafe). That early dispatch violated effect ordering anyway; the explicit `prestart` hint API (planned follow-up) is the principled way to opt back in.

## Tests

`test/test_dead_branch_prestart.rb` (+ fixtures): classification (dead-branch dep in neither prestart set), execution (never runs), and the headline case (raising dead-branch dep no longer fails the run). All three RED on master.

`rake test` 738 / 0, `rake standard` clean.

Found by an hypothesis-driven design review of the speculation lifecycle ("prestart must be regret-free: only certainly-read deps may speculate"); missed by all prior line-level reviews because the classification logic is correct — the bug is the *collection range mismatch* between the two phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)