### PR TITLE
Await speculative tasks before run_main_loop exits

### DIFF
--- a/lib/taski/execution/executor.rb
+++ b/lib/taski/execution/executor.rb
@@ -101,7 +101,15 @@ module Taski
       end
 
       def run_main_loop(root_task_class)
-        until @scheduler.finished?(root_task_class)
+        # Wait for the root AND every still-running (speculatively prestarted)
+        # task. Exiting on the root alone abandons parked fibers: shutdown's
+        # :shutdown sentinel reaches a parked task's worker before the Resume
+        # its slow dep pushes on completion, so the fiber dies mid-run — its
+        # ensure never executes and its wrapper is stuck :running while run()
+        # reports success. Every task marked running is guaranteed a terminal
+        # completion-queue event (StartDepNotify is pushed before its Execute
+        # command), so waiting here cannot deadlock.
+        until @scheduler.finished?(root_task_class) && !@scheduler.running_tasks?
           break if @registry.abort_requested? && !@scheduler.running_tasks?
 
           event = @completion_queue.pop

--- a/test/fixtures/speculative_completion_tasks.rb
+++ b/test/fixtures/speculative_completion_tasks.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "taski"
+
+# Fixtures for the speculative-task completion guarantee: a prestarted task
+# that is parked on a slow dep when the root finishes must still run to
+# completion (its ensure must execute) before run() returns.
+module SpeculativeCompletionFixtures
+  class SlowInner < Taski::Task
+    exports :value
+
+    def run
+      sleep 0.4
+      @value = "inner"
+    end
+  end
+
+  # Prestarted by FastRoot. Reads SlowInner with a phase-2 sync demotion
+  # (argument use), so SlowInner is prestarted AND the read parks on the
+  # already-running dep — putting this task in the parked state when the
+  # root completes.
+  class SpeculativeOuter < Taski::Task
+    exports :value
+
+    class << self
+      attr_accessor :completed, :ensure_ran
+    end
+
+    def run
+      v = SlowInner.value
+      @match = ["inner"].include?(v)
+      self.class.completed = true
+      @value = "outer: #{v}"
+    ensure
+      self.class.ensure_ran = true
+    end
+  end
+
+  # Completes immediately: reads SpeculativeOuter as a proxy that is never
+  # forced (stored in a non-exported ivar), so nothing in this task ever
+  # waits for the speculative chain.
+  class FastRoot < Taski::Task
+    exports :value
+
+    def run
+      a = SpeculativeOuter.value
+      @hold = a
+      @value = "fast"
+    end
+  end
+end

--- a/test/test_speculative_completion.rb
+++ b/test/test_speculative_completion.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "timeout"
+require_relative "fixtures/speculative_completion_tasks"
+
+# Every dispatched task must reach a terminal state before run() returns —
+# speculation must not outlive the execution. A prestarted task parked on a
+# slow dep when the root finishes must be resumed and run to completion
+# (its ensure must execute), not silently abandoned mid-run.
+class TestSpeculativeCompletion < Minitest::Test
+  def setup
+    Taski::Task.reset! if defined?(Taski::Task)
+    Taski::StaticAnalysis::StartDepAnalyzer.clear_cache!
+    SpeculativeCompletionFixtures::SpeculativeOuter.completed = false
+    SpeculativeCompletionFixtures::SpeculativeOuter.ensure_ran = false
+  end
+
+  def test_speculative_task_parked_on_slow_dep_runs_to_completion
+    Timeout.timeout(15) do
+      SpeculativeCompletionFixtures::FastRoot.run(workers: 4)
+    end
+
+    assert SpeculativeCompletionFixtures::SpeculativeOuter.completed,
+      "a prestarted task parked on a slow dep was abandoned instead of run to completion"
+    assert SpeculativeCompletionFixtures::SpeculativeOuter.ensure_ran,
+      "the abandoned task's ensure block never executed"
+  end
+end


### PR DESCRIPTION
## Bug

`run_main_loop` exited as soon as the **root** finished. A speculatively prestarted task still **parked on a slow dep** at that moment was silently abandoned:

1. `shutdown` pushes `:shutdown` to every worker queue; the parked task's worker pops it and exits.
2. When the slow dep completes (on another worker, which the shutdown join was already waiting for), its `mark_completed` pushes `Resume(fiber)` onto the **dead** worker's queue — never processed.
3. The fiber dies mid-run: its `ensure` **never executes** (resource cleanup written there silently leaks), the wrapper is stuck `:running`, and `run()` reports success with zero diagnostics.

Reproduced deterministically: `FastRoot` reads `SpeculativeOuter` via a never-forced proxy; `SpeculativeOuter` parks on `SlowInner` (0.4s). On master, `SpeculativeOuter`'s body after the park and its `ensure` never run.

## Fix

```ruby
until @scheduler.finished?(root_task_class) && !@scheduler.running_tasks?
```

Every dispatched task reaches a terminal state before `run()` returns — sequential semantics ("a read dep runs to completion") and the structured-concurrency principle (no work outlives the execution).

**No deadlock**: every task marked running is guaranteed a terminal completion-queue event — `StartDepNotify` is pushed *before* its `Execute` command, so a running-marked task always has a `TaskCompleted`/`TaskFailed` coming. The abort break already required the same `!running_tasks?` drain, so abort behavior is unchanged.

**No wall-clock cost**: master's shutdown join already waited for the busy worker (the repro took ~0.42s on master too) — the bug was the *lost Resume*, not an early return. Only the completion semantics change.

Note: with this fix, speculative dispatch becomes a strict commitment (a prestarted task always runs to completion), which is also what makes the planned explicit `prestart` hint API safe to ship. Pairs with #226 (which stops dispatching deps that sequential semantics never read).

## Tests

`test/test_speculative_completion.rb` (+ fixtures): the parked speculative task completes and its `ensure` runs before `run()` returns. RED on master, GREEN with the fix.

`rake test` 736 / 0, `rake standard` clean. Independently pre-verified in a worktree by the design-review workflow (full suite + abort paths + deadlock analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a critical issue where speculatively started tasks could be abandoned mid-execution without completing their cleanup handlers and lifecycle callbacks, preventing potential deadlocks and ensuring consistent task state reporting across the execution lifecycle.

* **Tests**
  * Added comprehensive test suite validating that parked tasks on slow dependencies properly run to completion and execute all necessary cleanup handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->