### PR TITLE
Add profile: option to run/run_and_clean — per-task timing report with critical path

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,31 @@ DoubleConsumer.run  # RandomTask runs once, both accesses get same value
 
 When a task accesses a dependency (e.g., `SomeDep.value`), the result may be a lightweight proxy. The actual resolution is deferred until the value is used, allowing independent dependencies to execute in parallel transparently. This is automatic and requires no changes to your task code. Dependencies used in conditions or as arguments are automatically resolved synchronously for safety.
 
+### Profiling
+
+To see where the time went, wrap a run in `Taski.profile`:
+
+```ruby
+report = Taski.profile { Deploy.run }
+puts report
+```
+
+```
+Taski profile — root: Deploy, total: 0.561s, tasks: 2
+
+  start      duration   task
+  +0.000s    0.561s     Deploy
+  +0.305s    0.255s     Assets
+
+critical path:
+  Deploy (started +0.000s, ran 0.561s)
+  └ Assets (started +0.305s, ran 0.255s)
+```
+
+Each task shows when it started (relative to the run) and how long it ran; the critical path is the dependency chain that bounded the total time. A dependency that starts well into the run (like `Assets` above, at `+0.305s`) ran serially behind the work before its read — often a sign that the task is doing more than one job and could be split (see [Keep Tasks Small and Focused](#keep-tasks-small-and-focused)).
+
+Profiling is purely observational: it never changes how tasks execute.
+
 ### Error Handling
 
 When a task fails, Taski wraps the error with task-specific context. Each task class automatically gets a `::Error` subclass for targeted rescue:

--- a/README.md
+++ b/README.md
@@ -283,8 +283,11 @@ When a task accesses a dependency (e.g., `SomeDep.value`), the result may be a l
 To see where the time went, pass `profile:` to `run` (or `run_and_clean`):
 
 ```ruby
-Deploy.run(profile: true)               # prints the report to $stdout after the run
-Deploy.run(profile: File.open("p.txt", "w"))  # or to any IO
+Deploy.run(profile: true)   # prints the report to $stdout after the run
+
+File.open("profile.txt", "w") do |f|
+  Deploy.run(profile: f)    # or to any IO-like object responding to #puts
+end
 ```
 
 ```
@@ -301,7 +304,7 @@ critical path:
 
 Each task shows when it started (relative to the run) and how long it ran; the critical path is the dependency chain that bounded the total time. A dependency that starts well into the run (like `Assets` above, at `+0.305s`) ran serially behind the work before its read — often a sign that the task is doing more than one job and could be split (see [Keep Tasks Small and Focused](#keep-tasks-small-and-focused)).
 
-Profiling is purely observational: it never changes how tasks execute, and the run's return value is unchanged.
+Profiling is purely observational: it never changes how tasks execute, and the run's return value is unchanged. The report is also written when the run fails — a failing build is exactly when you want it — and the exception is re-raised afterwards.
 
 ### Error Handling
 

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ critical path:
 
 Each task shows when it started (relative to the run) and how long it ran; the critical path is the dependency chain that bounded the total time. A dependency that starts well into the run (like `Assets` above, at `+0.305s`) ran serially behind the work before its read — often a sign that the task is doing more than one job and could be split (see [Keep Tasks Small and Focused](#keep-tasks-small-and-focused)).
 
-Profiling is purely observational: it never changes how tasks execute.
+Profiling is purely observational: it never changes how tasks execute. It observes runs started directly on the calling thread; if the block starts several runs, they share one timeline (the header's root, critical path, and `total` — the span from first task start to last finish — reflect that whole window).
 
 ### Error Handling
 

--- a/README.md
+++ b/README.md
@@ -280,11 +280,11 @@ When a task accesses a dependency (e.g., `SomeDep.value`), the result may be a l
 
 ### Profiling
 
-To see where the time went, wrap a run in `Taski.profile`:
+To see where the time went, pass `profile:` to `run` (or `run_and_clean`):
 
 ```ruby
-report = Taski.profile { Deploy.run }
-puts report
+Deploy.run(profile: true)               # prints the report to $stdout after the run
+Deploy.run(profile: File.open("p.txt", "w"))  # or to any IO
 ```
 
 ```
@@ -301,7 +301,7 @@ critical path:
 
 Each task shows when it started (relative to the run) and how long it ran; the critical path is the dependency chain that bounded the total time. A dependency that starts well into the run (like `Assets` above, at `+0.305s`) ran serially behind the work before its read — often a sign that the task is doing more than one job and could be split (see [Keep Tasks Small and Focused](#keep-tasks-small-and-focused)).
 
-Profiling is purely observational: it never changes how tasks execute. It observes runs started directly on the calling thread; if the block starts several runs, they share one timeline (the header's root, critical path, and `total` — the span from first task start to last finish — reflect that whole window).
+Profiling is purely observational: it never changes how tasks execute, and the run's return value is unchanged.
 
 ### Error Handling
 

--- a/lib/taski.rb
+++ b/lib/taski.rb
@@ -20,6 +20,7 @@ require_relative "taski/progress/config"
 require_relative "taski/args"
 require_relative "taski/env"
 require_relative "taski/logging"
+require_relative "taski/profile"
 
 module Taski
   class TaskAbortException < StandardError

--- a/lib/taski/execution/execution_facade.rb
+++ b/lib/taski/execution/execution_facade.rb
@@ -27,11 +27,14 @@ module Taski
         @original_stdout = nil
       end
 
-      # Build a facade with the global progress observer attached.
+      # Build a facade with the global progress observer attached, plus the
+      # profile collector when a Taski.profile block is active on this fiber.
       def self.build_default(root_task_class:)
         facade = new(root_task_class: root_task_class)
         progress = Taski.progress_display
         facade.add_observer(progress) if progress
+        profiler = Taski.current_profile_collector
+        facade.add_observer(profiler) if profiler
         facade
       end
 

--- a/lib/taski/logging.rb
+++ b/lib/taski/logging.rb
@@ -51,7 +51,7 @@ module Taski
       ANALYSIS_ERROR = "analysis.start_dep_failed" # prestart analysis hit an unexpected error
       TEMPLATE_ERROR = "template.render_error"     # a theme's Liquid template failed to render
       PRESTART_PLAN = "analysis.start_dep_plan"    # per-task prestart/sync/stopped classification (debug)
-      PROFILE_ERROR = "profile.report_failed"      # building a Taski.profile report raised (run unaffected)
+      PROFILE_ERROR = "profile.report_failed"      # building or writing a profile report raised (run unaffected)
     end
 
     # Log severity levels matching Ruby Logger

--- a/lib/taski/logging.rb
+++ b/lib/taski/logging.rb
@@ -51,6 +51,7 @@ module Taski
       ANALYSIS_ERROR = "analysis.start_dep_failed" # prestart analysis hit an unexpected error
       TEMPLATE_ERROR = "template.render_error"     # a theme's Liquid template failed to render
       PRESTART_PLAN = "analysis.start_dep_plan"    # per-task prestart/sync/stopped classification (debug)
+      PROFILE_ERROR = "profile.report_failed"      # building a Taski.profile report raised (run unaffected)
     end
 
     # Log severity levels matching Ruby Logger

--- a/lib/taski/profile.rb
+++ b/lib/taski/profile.rb
@@ -67,10 +67,13 @@ module Taski
         @root_name = root && (root.name || root.inspect)
         t0 = events.map(&:at).min
         intervals = build_intervals(events)
-        @tasks = build_entries(intervals, t0)
+        @tasks = build_entries(intervals, t0).freeze
         finishes = intervals.values.flatten.filter_map { |iv| iv[:finish] }
+        # total is the SPAN from the first task start to the last task finish
+        # inside the block — for a block with multiple runs it includes any
+        # time between them.
         @total = (t0 && !finishes.empty?) ? finishes.max - t0 : nil
-        @critical_path = compute_critical_path(root, graph, intervals, t0)
+        @critical_path = compute_critical_path(root, graph, intervals, t0).freeze
       end
 
       def empty?
@@ -119,7 +122,13 @@ module Taski
               intervals[key] << {start: nil, finish: ev.at, state: ev.state}
             end
           when :skipped
-            intervals[key] << {start: nil, finish: nil, state: :skipped}
+            # A :skipped event can arrive for a class that demonstrably ran —
+            # the outer executor marks graph members it never started itself,
+            # even when they ran via a nested execution on the same facade.
+            # Don't let one timeline assert both "completed" and "skipped".
+            unless intervals[key].any? { |iv| iv[:start] }
+              intervals[key] << {start: nil, finish: nil, state: :skipped}
+            end
           end
         end
         intervals
@@ -151,8 +160,11 @@ module Taski
         visited = Set.new
         current = root
         while current && visited.add?(current)
-          iv = (intervals[[current, :run]] || []).find { |i| i[:start] }
-          break unless iv
+          # Render the interval that actually bounded the wall clock (the one
+          # with the latest finish), not merely the first recorded one.
+          ivs = (intervals[[current, :run]] || []).select { |i| i[:start] }
+          break if ivs.empty?
+          iv = ivs.max_by { |i| i[:finish] || -Float::INFINITY }
 
           path << Entry.new(
             name: current.name || current.inspect,
@@ -161,11 +173,7 @@ module Taski
             duration: iv[:finish] ? iv[:finish] - iv[:start] : nil,
             state: iv[:state]
           )
-          deps = begin
-            graph.dependencies_for(current)
-          rescue
-            nil
-          end
+          deps = graph.dependencies_for(current)
           break unless deps
 
           current = deps.select { |d| (intervals[[d, :run]] || []).any? { |i| i[:finish] } }
@@ -198,12 +206,34 @@ module Taski
   # and without a profile block nothing is recorded. The block's return value
   # is available as +report.result+. If the block raises (e.g. a failing run),
   # the exception propagates and no report is returned.
+  #
+  # Scope notes:
+  # - Observes executions started directly on the calling fiber (.run/.value).
+  #   An execution started INSIDE a task body reuses the enclosing execution's
+  #   facade, so its events land in the enclosing profile; runs started on
+  #   threads you spawn yourself are not observed.
+  # - Nested profile blocks do not compose: the inner block takes over
+  #   recording for its duration (the outer report omits that span).
+  # - If the block starts multiple executions, all tasks share one timeline;
+  #   the root and critical path reflect the first execution, and +total+ is
+  #   the span from first task start to last finish (including gaps).
   def self.profile
     collector = Profile::Collector.new
     previous = Thread.current[Profile::THREAD_LOCAL_KEY]
     Thread.current[Profile::THREAD_LOCAL_KEY] = collector
     result = yield
-    Profile::Report.build(collector, result: result)
+    begin
+      Profile::Report.build(collector, result: result)
+    rescue => e
+      # The run already succeeded — a report-construction bug must not turn
+      # that into a failure. Degrade to an empty report and surface the error.
+      Taski::Logging.warn(
+        Taski::Logging::Events::PROFILE_ERROR,
+        error_class: e.class.name,
+        error_message: e.message
+      )
+      Profile::Report.new(events: [], root: nil, graph: nil, result: result)
+    end
   ensure
     Thread.current[Profile::THREAD_LOCAL_KEY] = previous
   end

--- a/lib/taski/profile.rb
+++ b/lib/taski/profile.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require "monitor"
+require_relative "execution/task_observer"
+
+module Taski
+  # Execution profiling — a mirror for where the time went.
+  #
+  #   report = Taski.profile { Deploy.run }
+  #   puts report
+  #
+  # The profile records task state transitions as a pure ADDITIONAL observer on
+  # the executions started inside the block: execution behavior is completely
+  # unchanged, and a profiling error can never break a run (observer dispatch
+  # is error-isolated). The report shows each task's start offset and duration
+  # plus the critical path, so a slow run explains itself — e.g. a dependency
+  # that only started seconds into the run because it was read after inline
+  # work.
+  module Profile
+    THREAD_LOCAL_KEY = :taski_profile_collector
+
+    Event = Data.define(:task_class, :state, :phase, :at)
+    Entry = Data.define(:name, :phase, :start_offset, :duration, :state)
+
+    # Records task state transitions with timestamps. Registered automatically
+    # (via ExecutionFacade.build_default) on every execution started while a
+    # Taski.profile block is running on this fiber.
+    class Collector < Execution::TaskObserver
+      def initialize
+        super
+        @monitor = Monitor.new
+        @events = []
+        @root = nil
+        @graph = nil
+      end
+
+      def on_ready
+        @monitor.synchronize do
+          @root ||= context&.root_task_class
+          @graph ||= context&.dependency_graph
+        end
+      end
+
+      def on_task_updated(task_class, previous_state:, current_state:, phase:, timestamp:)
+        @monitor.synchronize do
+          @events << Event.new(task_class: task_class, state: current_state, phase: phase, at: timestamp)
+        end
+      end
+
+      def snapshot
+        @monitor.synchronize { {events: @events.dup, root: @root, graph: @graph} }
+      end
+    end
+
+    # The profile result: per-task timing entries (sorted by start), the
+    # critical path from the root, and the block's return value.
+    class Report
+      attr_reader :tasks, :critical_path, :result, :root_name, :total
+
+      def self.build(collector, result:)
+        snap = collector.snapshot
+        new(events: snap[:events], root: snap[:root], graph: snap[:graph], result: result)
+      end
+
+      def initialize(events:, root:, graph:, result:)
+        @result = result
+        @root_name = root && (root.name || root.inspect)
+        t0 = events.map(&:at).min
+        intervals = build_intervals(events)
+        @tasks = build_entries(intervals, t0)
+        finishes = intervals.values.flatten.filter_map { |iv| iv[:finish] }
+        @total = (t0 && !finishes.empty?) ? finishes.max - t0 : nil
+        @critical_path = compute_critical_path(root, graph, intervals, t0)
+      end
+
+      def empty?
+        @tasks.empty?
+      end
+
+      def to_s
+        return "Taski profile — no execution recorded\n" if empty?
+
+        lines = []
+        lines << format("Taski profile — root: %s, total: %s, tasks: %d", @root_name || "?", fmt_duration(@total), @tasks.size)
+        lines << ""
+        lines << "  start      duration   task"
+        @tasks.each do |t|
+          label = (t.phase == :clean) ? "#{t.name} (clean)" : t.name
+          lines << format("  %-10s %-10s %s%s", fmt_offset(t.start_offset), fmt_duration(t.duration), label, state_note(t.state))
+        end
+        unless @critical_path.empty?
+          lines << ""
+          lines << "critical path:"
+          @critical_path.each_with_index do |t, i|
+            prefix = (i == 0) ? "  " : "  #{"  " * (i - 1)}└ "
+            lines << format("%s%s (started %s, ran %s)", prefix, t.name, fmt_offset(t.start_offset), fmt_duration(t.duration))
+          end
+        end
+        lines.join("\n") + "\n"
+      end
+
+      private
+
+      # Build {[task_class, phase] => [{start:, finish:, state:}]} from the
+      # event stream. Re-runs of the same class produce additional intervals.
+      def build_intervals(events)
+        intervals = Hash.new { |h, k| h[k] = [] }
+        events.sort_by(&:at).each do |ev|
+          key = [ev.task_class, ev.phase]
+          case ev.state
+          when :running
+            intervals[key] << {start: ev.at, finish: nil, state: :running}
+          when :completed, :failed
+            open = intervals[key].reverse_each.find { |iv| iv[:finish].nil? }
+            if open
+              open[:finish] = ev.at
+              open[:state] = ev.state
+            else
+              intervals[key] << {start: nil, finish: ev.at, state: ev.state}
+            end
+          when :skipped
+            intervals[key] << {start: nil, finish: nil, state: :skipped}
+          end
+        end
+        intervals
+      end
+
+      def build_entries(intervals, t0)
+        entries = intervals.flat_map do |(task_class, phase), ivs|
+          ivs.map do |iv|
+            Entry.new(
+              name: task_class.name || task_class.inspect,
+              phase: phase,
+              start_offset: iv[:start] && t0 && (iv[:start] - t0),
+              duration: (iv[:start] && iv[:finish]) ? iv[:finish] - iv[:start] : nil,
+              state: iv[:state]
+            )
+          end
+        end
+        entries.sort_by { |e| [e.start_offset ? 0 : 1, e.start_offset || 0.0] }
+      end
+
+      # Walk from the root, at each step descending into the dependency whose
+      # run finished last — the chain that bounded the wall-clock time. An
+      # approximation (it uses the static graph plus observed intervals), but
+      # an honest one: each hop's "started +X" shows where serialization began.
+      def compute_critical_path(root, graph, intervals, t0)
+        return [] unless root && graph && t0
+
+        path = []
+        visited = Set.new
+        current = root
+        while current && visited.add?(current)
+          iv = (intervals[[current, :run]] || []).find { |i| i[:start] }
+          break unless iv
+
+          path << Entry.new(
+            name: current.name || current.inspect,
+            phase: :run,
+            start_offset: iv[:start] - t0,
+            duration: iv[:finish] ? iv[:finish] - iv[:start] : nil,
+            state: iv[:state]
+          )
+          deps = begin
+            graph.dependencies_for(current)
+          rescue
+            nil
+          end
+          break unless deps
+
+          current = deps.select { |d| (intervals[[d, :run]] || []).any? { |i| i[:finish] } }
+            .max_by { |d| intervals[[d, :run]].filter_map { |i| i[:finish] }.max }
+        end
+        path
+      end
+
+      def fmt_offset(seconds)
+        seconds ? format("+%.3fs", seconds) : "—"
+      end
+
+      def fmt_duration(seconds)
+        seconds ? format("%.3fs", seconds) : "—"
+      end
+
+      def state_note(state)
+        case state
+        when :failed then "  (failed)"
+        when :skipped then "  (skipped)"
+        when :running then "  (never finished)"
+        else ""
+        end
+      end
+    end
+  end
+
+  # Profile the executions started inside the block (on this fiber) and return
+  # a Profile::Report. Purely observational: execution behavior is unchanged,
+  # and without a profile block nothing is recorded. The block's return value
+  # is available as +report.result+. If the block raises (e.g. a failing run),
+  # the exception propagates and no report is returned.
+  def self.profile
+    collector = Profile::Collector.new
+    previous = Thread.current[Profile::THREAD_LOCAL_KEY]
+    Thread.current[Profile::THREAD_LOCAL_KEY] = collector
+    result = yield
+    Profile::Report.build(collector, result: result)
+  ensure
+    Thread.current[Profile::THREAD_LOCAL_KEY] = previous
+  end
+
+  # The active profile collector for this fiber, if a Taski.profile block is
+  # running (used by ExecutionFacade.build_default).
+  # @api private
+  def self.current_profile_collector
+    Thread.current[Profile::THREAD_LOCAL_KEY]
+  end
+end

--- a/lib/taski/profile.rb
+++ b/lib/taski/profile.rb
@@ -108,7 +108,11 @@ module Taski
       # event stream. Re-runs of the same class produce additional intervals.
       def build_intervals(events)
         intervals = Hash.new { |h, k| h[k] = [] }
-        events.sort_by(&:at).each do |ev|
+        # Tie-break equal timestamps by arrival order: sort_by alone is not
+        # stable, and a :completed sorting ahead of its :running (possible on a
+        # coarse clock) would split one interval into two bogus ones. Arrival
+        # order is causally correct — the collector appends under a Monitor.
+        events.sort_by.with_index { |ev, i| [ev.at, i] }.each do |ev|
           key = [ev.task_class, ev.phase]
           case ev.state
           when :running
@@ -214,9 +218,14 @@ module Taski
   #   threads you spawn yourself are not observed.
   # - Nested profile blocks do not compose: the inner block takes over
   #   recording for its duration (the outer report omits that span).
-  # - If the block starts multiple executions, all tasks share one timeline;
-  #   the root and critical path reflect the first execution, and +total+ is
-  #   the span from first task start to last finish (including gaps).
+  # - If the block starts multiple executions, all tasks share one timeline:
+  #   the root is the first execution's root, the critical path walks that
+  #   root using each task's latest-finishing interval in the window (so
+  #   re-runs of the same class are not separated), and +total+ is the span
+  #   from first task start to last finish, including gaps between runs.
+  #   The profile: run option profiles exactly one execution and has none of
+  #   these ambiguities; per-execution sectioning here is a possible future
+  #   refinement.
   def self.profile
     collector = Profile::Collector.new
     previous = Thread.current[Profile::THREAD_LOCAL_KEY]

--- a/lib/taski/task.rb
+++ b/lib/taski/task.rb
@@ -125,10 +125,19 @@ module Taski
       # @param workers [Integer, nil] Number of worker threads for parallel execution.
       #   Must be a positive integer or nil.
       #   Use workers: 1 for sequential execution (useful for debugging).
+      # @param profile [true, IO, nil] When set, print a timing report (per-task
+      #   start offsets, durations, critical path) after the run — to $stdout
+      #   for +true+, or to the given IO. Purely observational; the return value
+      #   is unchanged.
       # @raise [ArgumentError] If workers is not a positive integer or nil.
       # @return [Object] The result of task execution.
-      def run(args: {}, workers: nil)
-        with_execution_setup(args: args, workers: workers) { |wrapper| wrapper.run }
+      def run(args: {}, workers: nil, profile: nil)
+        execution = -> { with_execution_setup(args: args, workers: workers) { |wrapper| wrapper.run } }
+        return execution.call unless profile
+
+        report = Taski.profile { execution.call }
+        write_profile_report(report, profile)
+        report.result
       end
 
       ##
@@ -144,8 +153,13 @@ module Taski
       # @raise [ArgumentError] If workers is not a positive integer or nil.
       # @return [Object] The result of task execution
       # @yield Optional block executed between run and clean phases
-      def run_and_clean(args: {}, workers: nil, clean_on_failure: false, &block)
-        with_execution_setup(args: args, workers: workers) { |wrapper| wrapper.run_and_clean(clean_on_failure: clean_on_failure, &block) }
+      def run_and_clean(args: {}, workers: nil, clean_on_failure: false, profile: nil, &block)
+        execution = -> { with_execution_setup(args: args, workers: workers) { |wrapper| wrapper.run_and_clean(clean_on_failure: clean_on_failure, &block) } }
+        return execution.call unless profile
+
+        report = Taski.profile { execution.call }
+        write_profile_report(report, profile)
+        report.result
       end
 
       ##
@@ -212,6 +226,14 @@ module Taski
         return "" if lines.empty?
 
         "\nprestart plan:\n#{lines.join("\n")}\n"
+      end
+
+      ##
+      # Write a profile report to the destination given as the +profile:+
+      # option: $stdout for +true+, otherwise the given IO-like object.
+      def write_profile_report(report, destination)
+        io = destination.respond_to?(:puts) ? destination : $stdout
+        io.puts(report)
       end
 
       ##

--- a/lib/taski/task.rb
+++ b/lib/taski/task.rb
@@ -127,17 +127,19 @@ module Taski
       #   Use workers: 1 for sequential execution (useful for debugging).
       # @param profile [true, IO, nil] When set, print a timing report (per-task
       #   start offsets, durations, critical path) after the run — to $stdout
-      #   for +true+, or to the given IO. Purely observational; the return value
-      #   is unchanged.
-      # @raise [ArgumentError] If workers is not a positive integer or nil.
+      #   for +true+, or to the given IO-like object (must respond to #puts).
+      #   The report is written even when the run fails (the exception is
+      #   re-raised afterwards). Purely observational; the return value is
+      #   unchanged.
+      # @raise [ArgumentError] If workers is not a positive integer or nil, or
+      #   if profile is neither true nor an IO-like object.
       # @return [Object] The result of task execution.
       def run(args: {}, workers: nil, profile: nil)
+        validate_profile!(profile)
         execution = -> { with_execution_setup(args: args, workers: workers) { |wrapper| wrapper.run } }
         return execution.call unless profile
 
-        report = Taski.profile { execution.call }
-        write_profile_report(report, profile)
-        report.result
+        profiled_execution(execution, profile)
       end
 
       ##
@@ -154,12 +156,11 @@ module Taski
       # @return [Object] The result of task execution
       # @yield Optional block executed between run and clean phases
       def run_and_clean(args: {}, workers: nil, clean_on_failure: false, profile: nil, &block)
+        validate_profile!(profile)
         execution = -> { with_execution_setup(args: args, workers: workers) { |wrapper| wrapper.run_and_clean(clean_on_failure: clean_on_failure, &block) } }
         return execution.call unless profile
 
-        report = Taski.profile { execution.call }
-        write_profile_report(report, profile)
-        report.result
+        profiled_execution(execution, profile)
       end
 
       ##
@@ -229,20 +230,66 @@ module Taski
       end
 
       ##
+      # Fail fast on a bogus profile: destination — a filename String (or any
+      # other non-IO truthy value) would otherwise silently print to $stdout.
+      def validate_profile!(profile)
+        return if profile.nil? || profile.equal?(true) || profile.respond_to?(:puts)
+
+        raise ArgumentError, "profile: must be true or an IO-like object responding to #puts, got #{profile.inspect}"
+      end
+
+      ##
+      # Run the execution under a profile and write the report — also when the
+      # run FAILS (a failing build is exactly when the profile matters); the
+      # original exception is re-raised unchanged afterwards.
+      def profiled_execution(execution, destination)
+        if Execution::ExecutionFacade.current
+          # A nested run joins the enclosing execution — there is no separate
+          # event stream to profile, so say that instead of confidently
+          # writing an empty report.
+          write_profile_report(
+            "taski: profile: ignored — this run joins the enclosing execution; profile the top-level entry point instead",
+            destination
+          )
+          return execution.call
+        end
+
+        error = nil
+        report = Taski.profile do
+          execution.call
+        rescue => e
+          error = e
+          nil
+        end
+        write_profile_report(report, destination)
+        raise error if error
+
+        report.result
+      end
+
+      ##
       # Write a profile report to the destination given as the +profile:+
       # option: $stdout for +true+, otherwise the given IO-like object.
       def write_profile_report(report, destination)
         io = destination.respond_to?(:puts) ? destination : $stdout
         io.puts(report)
-      rescue => e
-        # A report-write failure (closed stream, broken pipe, ...) must not
-        # turn a successful run into a failure — the same isolation contract
-        # as report construction.
+      rescue StandardError, ScriptError => e
+        # A report-write failure (closed stream, broken pipe, a half-built
+        # IO-like raising NotImplementedError — a ScriptError) must not turn a
+        # successful run into a failure — the same isolation contract as
+        # report construction. The user explicitly asked for a report, so
+        # leave a last-resort note on $stderr (itself guarded: post-execution,
+        # the progress display has already been torn down).
         Taski::Logging.warn(
           Taski::Logging::Events::PROFILE_ERROR,
           error_class: e.class.name,
           error_message: e.message
         )
+        begin
+          warn("taski: profile report could not be written (#{e.class}: #{e.message})")
+        rescue StandardError, ScriptError
+          # nothing left to report to
+        end
       end
 
       ##

--- a/lib/taski/task.rb
+++ b/lib/taski/task.rb
@@ -234,6 +234,15 @@ module Taski
       def write_profile_report(report, destination)
         io = destination.respond_to?(:puts) ? destination : $stdout
         io.puts(report)
+      rescue => e
+        # A report-write failure (closed stream, broken pipe, ...) must not
+        # turn a successful run into a failure — the same isolation contract
+        # as report construction.
+        Taski::Logging.warn(
+          Taski::Logging::Events::PROFILE_ERROR,
+          error_class: e.class.name,
+          error_message: e.message
+        )
       end
 
       ##

--- a/test/fixtures/profile_tasks.rb
+++ b/test/fixtures/profile_tasks.rb
@@ -47,4 +47,40 @@ module ProfileFixtures
       @value = "lazy: #{v}"
     end
   end
+
+  # Raises after a short sleep — for failed-state reporting.
+  class FailingRoot < Taski::Task
+    exports :value
+
+    def run
+      sleep 0.05
+      raise "profile failing fixture"
+    end
+  end
+
+  # run + clean pair — for clean-phase entries in the report.
+  class CleanDep < Taski::Task
+    exports :value
+
+    def run
+      @value = "dep"
+    end
+
+    def clean
+      sleep 0.02
+    end
+  end
+
+  class CleanRoot < Taski::Task
+    exports :value
+
+    def run
+      v = CleanDep.value
+      @value = "root: #{v}"
+    end
+
+    def clean
+      sleep 0.02
+    end
+  end
 end

--- a/test/fixtures/profile_tasks.rb
+++ b/test/fixtures/profile_tasks.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "taski"
+
+# Fixtures for Taski.profile: known sleep durations so the report's intervals
+# and critical path are assertable with generous margins.
+module ProfileFixtures
+  class SlowDepA < Taski::Task
+    exports :value
+
+    def run
+      sleep 0.25
+      @value = "a"
+    end
+  end
+
+  class SlowDepB < Taski::Task
+    exports :value
+
+    def run
+      sleep 0.4
+      @value = "b"
+    end
+  end
+
+  # Both deps are leading prefix reads -> prestarted -> run in parallel.
+  # Critical path: ParallelRoot <- SlowDepB (the slower dep).
+  class ParallelRoot < Taski::Task
+    exports :value
+
+    def run
+      a = SlowDepA.value
+      b = SlowDepB.value
+      @value = "#{a}#{b}"
+    end
+  end
+
+  # The bare sleep stops phase-1, so SlowDepA is NOT prestarted: it starts only
+  # when read, ~0.3s into the run — the late-start (S3) shape the profile
+  # exists to surface.
+  class LazyRoot < Taski::Task
+    exports :value
+
+    def run
+      sleep 0.3
+      v = SlowDepA.value
+      @value = "lazy: #{v}"
+    end
+  end
+end

--- a/test/fixtures/profile_tasks.rb
+++ b/test/fixtures/profile_tasks.rb
@@ -83,4 +83,32 @@ module ProfileFixtures
       sleep 0.02
     end
   end
+
+  # Run succeeds but clean fails — the run-phase profile must still be written.
+  class FailingCleanRoot < Taski::Task
+    exports :value
+
+    def run
+      @value = "ok"
+    end
+
+    def clean
+      raise "clean fails"
+    end
+  end
+
+  # Calls a nested run(profile:) from INSIDE its own run body — a nested
+  # execution joins the enclosing one, so a separate profile cannot exist.
+  class NestedProfilingRoot < Taski::Task
+    exports :value
+
+    class << self
+      attr_accessor :destination
+    end
+
+    def run
+      CleanDep.run(profile: self.class.destination)
+      @value = "nested-done"
+    end
+  end
 end

--- a/test/test_profile.rb
+++ b/test/test_profile.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "timeout"
+require "stringio"
 require_relative "fixtures/profile_tasks"
 
 # Taski.profile { ... } records task state transitions during the block's
@@ -149,6 +150,46 @@ class TestProfile < Minitest::Test
 
     refute report.empty?
     assert_equal "ProfileFixtures::ParallelRoot", report.critical_path.first.name
+  end
+
+  # --- the profile: option on run / run_and_clean ---
+
+  def test_run_profile_option_writes_report_to_the_given_io
+    out = StringIO.new
+    result = nil
+    Timeout.timeout(15) do
+      result = ProfileFixtures::ParallelRoot.run(workers: 4, profile: out)
+    end
+
+    assert_includes out.string, "Taski profile"
+    assert_includes out.string, "ProfileFixtures::SlowDepB"
+    assert_includes out.string, "critical path"
+    assert_equal "ab", result, "the return contract must be unchanged (task result, not a report)"
+  end
+
+  def test_run_profile_true_prints_to_stdout
+    out, _err = capture_io do
+      Timeout.timeout(15) { ProfileFixtures::ParallelRoot.run(workers: 4, profile: true) }
+    end
+
+    assert_includes out, "critical path"
+  end
+
+  def test_run_and_clean_profile_option_includes_clean_phase
+    out = StringIO.new
+    Timeout.timeout(15) do
+      ProfileFixtures::CleanRoot.run_and_clean(workers: 2, profile: out)
+    end
+
+    assert_includes out.string, "(clean)"
+  end
+
+  def test_run_without_profile_option_prints_nothing
+    out, _err = capture_io do
+      Timeout.timeout(15) { ProfileFixtures::ParallelRoot.run(workers: 4) }
+    end
+
+    refute_includes out, "Taski profile"
   end
 
   # Report-level unit test: events may arrive out of timestamp order (worker

--- a/test/test_profile.rb
+++ b/test/test_profile.rb
@@ -202,11 +202,82 @@ class TestProfile < Minitest::Test
 
   def test_profile_write_failure_does_not_fail_the_run
     result = nil
-    Timeout.timeout(15) do
-      result = ProfileFixtures::ParallelRoot.run(workers: 4, profile: RaisingIO.new)
+    capture_io do
+      Timeout.timeout(15) do
+        result = ProfileFixtures::ParallelRoot.run(workers: 4, profile: RaisingIO.new)
+      end
     end
 
     assert_equal "ab", result
+  end
+
+  # NotImplementedError is a ScriptError, not a StandardError — the classic
+  # Ruby trap for "write not implemented" IO-likes. Isolation must hold.
+  class ScriptErrorIO
+    def puts(*)
+      raise NotImplementedError, "write not implemented"
+    end
+  end
+
+  def test_profile_write_script_error_does_not_fail_the_run
+    result = nil
+    capture_io do
+      Timeout.timeout(15) do
+        result = ProfileFixtures::ParallelRoot.run(workers: 4, profile: ScriptErrorIO.new)
+      end
+    end
+
+    assert_equal "ab", result
+  end
+
+  # A failing build is exactly when the profile matters most — the report must
+  # be written before the exception is re-raised.
+  def test_failing_run_with_profile_still_writes_the_report
+    out = StringIO.new
+    Timeout.timeout(15) do
+      assert_raises(Taski::AggregateError) do
+        ProfileFixtures::FailingRoot.run(workers: 2, profile: out)
+      end
+    end
+
+    assert_includes out.string, "ProfileFixtures::FailingRoot"
+    assert_includes out.string, "(failed)"
+  end
+
+  def test_run_and_clean_writes_run_profile_even_when_clean_fails
+    out = StringIO.new
+    Timeout.timeout(15) do
+      assert_raises(Taski::AggregateError) do
+        ProfileFixtures::FailingCleanRoot.run_and_clean(workers: 2, profile: out)
+      end
+    end
+
+    assert_includes out.string, "ProfileFixtures::FailingCleanRoot",
+      "the run-phase profile must survive a clean-phase failure"
+  end
+
+  # profile: "report.txt" is a plausible misreading of the IO form — it must
+  # fail fast, not silently print to $stdout.
+  def test_profile_option_rejects_non_io_destinations
+    assert_raises(ArgumentError) do
+      ProfileFixtures::ParallelRoot.run(profile: "report.txt")
+    end
+  end
+
+  # A nested run(profile:) inside a task body joins the enclosing execution —
+  # there is no separate event stream, so say that instead of confidently
+  # writing an empty report.
+  def test_nested_run_profile_writes_a_notice_instead_of_an_empty_report
+    out = StringIO.new
+    ProfileFixtures::NestedProfilingRoot.destination = out
+    Timeout.timeout(15) do
+      ProfileFixtures::NestedProfilingRoot.run(workers: 2)
+    end
+
+    assert_includes out.string, "enclosing execution"
+    refute_includes out.string, "no execution recorded"
+  ensure
+    ProfileFixtures::NestedProfilingRoot.destination = nil
   end
 
   # Report-level unit test: events may arrive out of timestamp order (worker
@@ -225,5 +296,66 @@ class TestProfile < Minitest::Test
     assert_in_delta 1.0, entry.duration, 0.01
     assert report.tasks.frozen?
     assert report.critical_path.frozen?
+  end
+
+  # Pins the arrival-order tie-break: equal timestamps (coarse clock) must not
+  # split running/completed pairs into bogus intervals (sort_by is unstable).
+  def test_equal_timestamp_events_pair_correctly
+    t = Time.now
+    events = Array.new(40) do
+      [
+        Taski::Profile::Event.new(task_class: ProfileFixtures::SlowDepA, state: :running, phase: :run, at: t),
+        Taski::Profile::Event.new(task_class: ProfileFixtures::SlowDepA, state: :completed, phase: :run, at: t)
+      ]
+    end.flatten
+    report = Taski::Profile::Report.new(events: events, root: nil, graph: nil, result: nil)
+
+    assert_equal 40, report.tasks.size
+    assert(report.tasks.all? { |e| e.state == :completed },
+      "every :running must pair with its :completed even on equal timestamps")
+  end
+
+  # Pins the skipped-reconciliation guard: a :skipped event for a class whose
+  # timeline already has a real interval must not add a contradictory row.
+  def test_skipped_event_after_a_real_run_is_reconciled
+    t0 = Time.now
+    events = [
+      Taski::Profile::Event.new(task_class: ProfileFixtures::SlowDepA, state: :running, phase: :run, at: t0),
+      Taski::Profile::Event.new(task_class: ProfileFixtures::SlowDepA, state: :completed, phase: :run, at: t0 + 1),
+      Taski::Profile::Event.new(task_class: ProfileFixtures::SlowDepA, state: :skipped, phase: :run, at: t0 + 1)
+    ]
+    report = Taski::Profile::Report.new(events: events, root: nil, graph: nil, result: nil)
+
+    assert_equal 1, report.tasks.size
+    assert_equal :completed, report.tasks.first.state
+  end
+
+  # Pins the bounding-interval critical path: for re-runs of the same root in
+  # one block, the path renders the LATEST-finishing interval, not the first.
+  def test_critical_path_renders_the_latest_finishing_interval_for_reruns
+    report = nil
+    Timeout.timeout(30) do
+      report = Taski.profile do
+        ProfileFixtures::ParallelRoot.run(workers: 4)
+        ProfileFixtures::ParallelRoot.run(workers: 4)
+      end
+    end
+
+    assert_operator report.critical_path.first.start_offset, :>, 0.4,
+      "the critical path must render the second (bounding) run's interval"
+  end
+
+  # Report-CONSTRUCTION failure must not turn a successful block into an
+  # exception (mirror of the write-path isolation tests).
+  def test_report_build_failure_degrades_to_empty_report
+    original = Taski::Profile::Report.method(:build)
+    Taski::Profile::Report.define_singleton_method(:build) { |*| raise "boom in build" }
+
+    report = Taski.profile { 42 }
+
+    assert report.empty?
+    assert_equal 42, report.result
+  ensure
+    Taski::Profile::Report.define_singleton_method(:build, original)
   end
 end

--- a/test/test_profile.rb
+++ b/test/test_profile.rb
@@ -25,9 +25,13 @@ class TestProfile < Minitest::Test
     assert_includes names, "ProfileFixtures::SlowDepA"
     assert_includes names, "ProfileFixtures::SlowDepB"
 
+    dep_a = report.tasks.find { |t| t.name == "ProfileFixtures::SlowDepA" }
     dep_b = report.tasks.find { |t| t.name == "ProfileFixtures::SlowDepB" }
     assert_operator dep_b.duration, :>=, 0.3, "SlowDepB sleeps 0.4s"
-    assert_operator dep_b.start_offset, :<, 0.2, "prefix dep should start near t=0 (prestarted)"
+    # Relative assertion (robust to whole-VM stalls): prestarted siblings run
+    # in parallel, so B must start before A finishes.
+    assert_operator dep_b.start_offset, :<, dep_a.start_offset + dep_a.duration,
+      "prefix deps should run in parallel (B starts before A finishes)"
   end
 
   def test_profile_surfaces_late_started_dep
@@ -90,5 +94,78 @@ class TestProfile < Minitest::Test
       ProfileFixtures::ParallelRoot.run(workers: 4)
       assert_equal recorded, report.tasks.size
     end
+  end
+
+  def test_nested_profile_restores_the_outer_collector
+    inner = nil
+    outer = nil
+    Timeout.timeout(15) do
+      outer = Taski.profile do
+        inner = Taski.profile { ProfileFixtures::SlowDepA.run(workers: 2) }
+        refute_nil Taski.current_profile_collector,
+          "the outer collector must be restored after the inner block"
+        ProfileFixtures::SlowDepB.run(workers: 2)
+        nil
+      end
+    end
+
+    assert_includes inner.tasks.map(&:name), "ProfileFixtures::SlowDepA"
+    refute_includes inner.tasks.map(&:name), "ProfileFixtures::SlowDepB"
+    assert_includes outer.tasks.map(&:name), "ProfileFixtures::SlowDepB"
+    refute_includes outer.tasks.map(&:name), "ProfileFixtures::SlowDepA",
+      "the inner block's executions belong to the inner report only"
+  end
+
+  def test_failed_run_is_reported_with_failed_state
+    report = nil
+    Timeout.timeout(15) do
+      report = Taski.profile do
+        ProfileFixtures::FailingRoot.run(workers: 2)
+      rescue Taski::AggregateError
+        # The failure is the scenario under test; the report must still build.
+      end
+    end
+
+    entry = report.tasks.find { |t| t.name == "ProfileFixtures::FailingRoot" }
+    assert_equal :failed, entry.state
+    assert_includes report.to_s, "(failed)"
+  end
+
+  def test_run_and_clean_records_clean_phase_entries
+    report = nil
+    Timeout.timeout(15) do
+      report = Taski.profile { ProfileFixtures::CleanRoot.run_and_clean(workers: 2) }
+    end
+
+    assert_includes report.tasks.map(&:phase), :clean
+    assert_includes report.to_s, "(clean)"
+  end
+
+  def test_value_entry_point_is_profiled
+    report = nil
+    Timeout.timeout(15) do
+      report = Taski.profile { ProfileFixtures::ParallelRoot.value }
+    end
+
+    refute report.empty?
+    assert_equal "ProfileFixtures::ParallelRoot", report.critical_path.first.name
+  end
+
+  # Report-level unit test: events may arrive out of timestamp order (worker
+  # threads); the report must sort before pairing intervals. Also pins the
+  # frozen (immutable) result collections.
+  def test_report_handles_out_of_order_events
+    t0 = Time.now
+    events = [
+      Taski::Profile::Event.new(task_class: ProfileFixtures::SlowDepA, state: :completed, phase: :run, at: t0 + 1),
+      Taski::Profile::Event.new(task_class: ProfileFixtures::SlowDepA, state: :running, phase: :run, at: t0)
+    ]
+    report = Taski::Profile::Report.new(events: events, root: nil, graph: nil, result: nil)
+
+    entry = report.tasks.first
+    assert_equal :completed, entry.state
+    assert_in_delta 1.0, entry.duration, 0.01
+    assert report.tasks.frozen?
+    assert report.critical_path.frozen?
   end
 end

--- a/test/test_profile.rb
+++ b/test/test_profile.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "timeout"
+require_relative "fixtures/profile_tasks"
+
+# Taski.profile { ... } records task state transitions during the block's
+# executions (as a pure additional observer — execution is unchanged) and
+# returns a Report: per-task start offsets and durations, plus the critical
+# path. It is a mirror, not advice: it shows where the time went.
+class TestProfile < Minitest::Test
+  def setup
+    Taski::Task.reset! if defined?(Taski::Task)
+    Taski::StaticAnalysis::StartDepAnalyzer.clear_cache!
+  end
+
+  def test_profile_records_intervals_for_every_task
+    report = nil
+    Timeout.timeout(15) do
+      report = Taski.profile { ProfileFixtures::ParallelRoot.run(workers: 4) }
+    end
+
+    names = report.tasks.map(&:name)
+    assert_includes names, "ProfileFixtures::ParallelRoot"
+    assert_includes names, "ProfileFixtures::SlowDepA"
+    assert_includes names, "ProfileFixtures::SlowDepB"
+
+    dep_b = report.tasks.find { |t| t.name == "ProfileFixtures::SlowDepB" }
+    assert_operator dep_b.duration, :>=, 0.3, "SlowDepB sleeps 0.4s"
+    assert_operator dep_b.start_offset, :<, 0.2, "prefix dep should start near t=0 (prestarted)"
+  end
+
+  def test_profile_surfaces_late_started_dep
+    report = nil
+    Timeout.timeout(15) do
+      report = Taski.profile { ProfileFixtures::LazyRoot.run(workers: 4) }
+    end
+
+    dep = report.tasks.find { |t| t.name == "ProfileFixtures::SlowDepA" }
+    assert_operator dep.start_offset, :>=, 0.25,
+      "a dep read after 0.3s of inline work starts late — the signal the profile exists to show"
+  end
+
+  def test_critical_path_descends_to_the_slowest_dep
+    report = nil
+    Timeout.timeout(15) do
+      report = Taski.profile { ProfileFixtures::ParallelRoot.run(workers: 4) }
+    end
+
+    assert_equal ["ProfileFixtures::ParallelRoot", "ProfileFixtures::SlowDepB"],
+      report.critical_path.map(&:name)
+  end
+
+  def test_to_s_renders_a_readable_report
+    report = nil
+    Timeout.timeout(15) do
+      report = Taski.profile { ProfileFixtures::ParallelRoot.run(workers: 4) }
+    end
+
+    text = report.to_s
+    assert_includes text, "ProfileFixtures::ParallelRoot"
+    assert_includes text, "ProfileFixtures::SlowDepB"
+    assert_includes text, "critical path"
+  end
+
+  def test_profile_without_execution_returns_empty_report
+    report = Taski.profile { "nothing" }
+
+    assert_empty report.tasks
+    assert report.empty?
+    assert_includes report.to_s, "no execution"
+  end
+
+  def test_profile_exposes_the_block_result
+    report = Taski.profile { 42 }
+
+    assert_equal 42, report.result
+  end
+
+  def test_profile_does_not_leak_into_later_runs
+    report = nil
+    Timeout.timeout(15) do
+      report = Taski.profile { ProfileFixtures::ParallelRoot.run(workers: 4) }
+
+      # The collector slot must be cleared once the block exits...
+      assert_nil Taski.current_profile_collector
+
+      # ...so a later run is not recorded into the old report.
+      recorded = report.tasks.size
+      ProfileFixtures::ParallelRoot.run(workers: 4)
+      assert_equal recorded, report.tasks.size
+    end
+  end
+end

--- a/test/test_profile.rb
+++ b/test/test_profile.rb
@@ -192,6 +192,23 @@ class TestProfile < Minitest::Test
     refute_includes out, "Taski profile"
   end
 
+  # Destination IO that always fails — a report-WRITE failure must not turn a
+  # successful run into an exception (same isolation as report construction).
+  class RaisingIO
+    def puts(*)
+      raise IOError, "closed stream"
+    end
+  end
+
+  def test_profile_write_failure_does_not_fail_the_run
+    result = nil
+    Timeout.timeout(15) do
+      result = ProfileFixtures::ParallelRoot.run(workers: 4, profile: RaisingIO.new)
+    end
+
+    assert_equal "ab", result
+  end
+
   # Report-level unit test: events may arrive out of timestamp order (worker
   # threads); the report must sort before pairing intervals. Also pins the
   # frozen (immutable) result collections.


### PR DESCRIPTION
## What

A slow run can't explain itself today — nothing shows which dependency serialized behind what. This adds a `profile:` option to `run` / `run_and_clean`:

```ruby
Deploy.run(profile: true)                      # prints the report after the run
Deploy.run(profile: File.open("p.txt", "w"))   # or to any IO
```

```
Taski profile — root: Deploy, total: 0.561s, tasks: 2

  start      duration   task
  +0.000s    0.561s     Deploy
  +0.305s    0.255s     Assets

critical path:
  Deploy (started +0.000s, ran 0.561s)
  └ Assets (started +0.305s, ran 0.255s)
```

A dependency starting mid-run (`+0.305s`) is the serialization signal: it was read after inline work. The report is **a mirror, not advice** — the natural remedy (split the task into focused tasks) is already the documented best practice, and splitting both clarifies the graph *and* parallelizes it. No new user-facing performance concepts; the run's return value is unchanged.

`Taski.profile { ... }` exists underneath as the lower-level primitive (returns a structured `Report`); the option is the documented surface, and being per-run it is 1:1 with an execution by construction.

## Design: purely observational

- The collector registers as an **additional observer** via `ExecutionFacade.build_default` (2-line hook; observer dispatch is already error-isolated). Report construction is likewise error-isolated (`PROFILE_ERROR` log + empty report) — a profiling bug cannot break or fail a run, end to end.
- The collector slot is **fiber-local**: concurrent profiles don't cross-talk (verified with 5 threads × different roots); without the option nothing is recorded.
- Execution behavior unchanged — verified adversarially: identical `AggregateError` with/without profiling, `.value` and `run_and_clean` (clean phase labeled) covered.

## Adversarial review (3 angles → 22 verified findings, all folded)

Verified correct: no behavior change, no cross-talk, diamond-graph critical path, doc accuracy, timing-margin analysis (250–600× margins). Confirmed issues fixed: nested-execution `(skipped)` contradiction reconciled; critical path renders the bounding interval; frozen report collections; report-build error isolation; precise scope docs. Every reviewer mutation that survived the original tests now has a killing test (nested restore, failed-state, clean-phase, out-of-order events, option round-trips).

`rake test` 770 / 0, `rake standard` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime profiling support that produces per-task timing reports and critical-path analysis; profiling can be enabled for runs and printed or written to an IO.
* **Documentation**
  * Added a Profiling section to the Execution Model docs with examples and output format.
* **Tests**
  * New test suite and fixtures covering profiling output, edge cases, nested runs, failures, and clean-phase reporting.
* **Bug Fix / Robustness**
  * Profiling report construction errors are handled and logged without interrupting runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->