### PR TITLE
Reuse the open output pipe across fiber park/resume

### DIFF
--- a/lib/taski/execution/task_output_router.rb
+++ b/lib/taski/execution/task_output_router.rb
@@ -58,8 +58,17 @@ module Taski
 
       def start_capture(task_class)
         synchronize do
-          pipe = TaskOutputPipe.new(task_class)
-          @pipes[task_class] = pipe
+          existing = @pipes[task_class]
+          # Reuse an open pipe: a parked fiber's resume re-enters here, and
+          # replacing the pipe would orphan it with both FDs open (leaking
+          # until GC) and lose its undrained pre-park output from
+          # @recent_lines — and therefore from failure reports. A write-closed
+          # pipe (its phase finished via stop_capture) gets a fresh one. The
+          # resumed fiber may be on a different thread, so the thread_map is
+          # always re-pointed.
+          if existing.nil? || existing.write_closed?
+            @pipes[task_class] = TaskOutputPipe.new(task_class)
+          end
           @thread_map[Thread.current] = task_class
           Taski::Logging.debug(Taski::Logging::Events::OUTPUT_ROUTER_START_CAPTURE, task: task_class.name)
         end

--- a/test/test_task_output_router.rb
+++ b/test/test_task_output_router.rb
@@ -179,4 +179,51 @@ class TestTaskOutputRouter < Minitest::Test
 
     closer.join
   end
+
+  # ========================================
+  # Pipe reuse across park/resume
+  # ========================================
+  # A fiber that parks and resumes calls start_capture again for the same
+  # task. The open pipe must be REUSED: replacing it orphans a pipe whose two
+  # FDs leak until GC finalizes them, and any not-yet-polled output written
+  # before the park vanishes from @recent_lines (and thus from failure
+  # reports).
+
+  def test_start_capture_reuses_the_open_pipe_for_the_same_task
+    task_class = Class.new
+
+    @router.start_capture(task_class)
+    first = @router.instance_variable_get(:@pipes)[task_class]
+
+    @router.start_capture(task_class) # park -> resume re-entry
+    second = @router.instance_variable_get(:@pipes)[task_class]
+
+    assert_same first, second,
+      "re-capture must reuse the open pipe, not orphan it with both FDs open"
+  end
+
+  def test_pre_park_output_survives_recapture
+    task_class = Class.new
+
+    @router.start_capture(task_class)
+    @router.puts("PRE-PARK OUTPUT")
+
+    @router.start_capture(task_class) # resume re-entry before any poll
+    @router.poll
+
+    assert_equal "PRE-PARK OUTPUT", @router.last_line_for(task_class)
+  end
+
+  def test_start_capture_allocates_a_fresh_pipe_after_write_end_closed
+    task_class = Class.new
+
+    @router.start_capture(task_class)
+    first = @router.instance_variable_get(:@pipes)[task_class]
+    @router.stop_capture # closes the write end (e.g. run phase finished)
+
+    @router.start_capture(task_class) # e.g. clean phase for the same class
+    second = @router.instance_variable_get(:@pipes)[task_class]
+
+    refute_same first, second, "a write-closed pipe cannot be written to again"
+  end
 end


### PR DESCRIPTION
## Bugs (one root cause, two symptoms)

When a fiber parks on a dependency and later resumes, `resume_fiber_with_value` calls `start_output_capture` again — and `start_capture` unconditionally replaced the task's `TaskOutputPipe`:

1. **FD leak**: the replaced pipe was orphaned with **both** file descriptors open — outside `@pipes`, unreachable by `close_all`, leaking until GC finalized the IOs. N parks = 2N leaked FDs per execution. (Repro: 3 staggered parks with GC disabled → `/dev/fd` delta +6 after `close_all`; capture-off control: +0.)
2. **Pre-park output loss**: output written before the park sat undrained in the orphan, silently missing from `@recent_lines` — and therefore from `AggregateError`'s `Output:` sections — whenever the resume beat the ~100ms poll. (Repro: fast resume → 10/10 runs lost the output; slow resume → kept.)

## Fix

`start_capture` reuses the existing pipe while its write end is open: a parked task's pipe is fully functional and the poll thread keeps draining it; the resumed fiber may be on a different worker thread, so only the `thread_map` needs re-pointing. A fresh pipe is allocated only when none exists or the previous phase closed it via `stop_capture` (run → clean of the same class).

## Tests

Three router unit tests: same-pipe reuse on re-capture and pre-park output survival (both RED on master), plus the fresh-pipe-after-write-close guard pinning the phase-boundary behavior.

`rake test` 783 / 0, `rake standard` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)