### PR TITLE
Survive render-thread death: stop the spinner, restore the cursor

### DIFF
--- a/lib/taski/progress/layout/base.rb
+++ b/lib/taski/progress/layout/base.rb
@@ -543,7 +543,14 @@ module Taski
           start_spinner_timer
           @render_thread = Thread.new do
             while @render_thread_running
-              @monitor.synchronize(&block)
+              begin
+                @monitor.synchronize(&block)
+              rescue IOError, SystemCallError
+                # The terminal went away (closed stream, EPIPE). Rendering is
+                # pointless now — exit the loop cleanly instead of dying with
+                # an exception that join would re-raise during teardown.
+                break
+              end
               sleep @theme.render_interval
             end
           end
@@ -552,9 +559,23 @@ module Taski
         # Stop the periodic render loop and spinner timer.
         def stop_render_loop
           @render_thread_running = false
-          @render_thread&.join
-          @render_thread = nil
-          stop_spinner_timer
+          begin
+            # If the render thread died with an exception (anything the loop's
+            # own rescue didn't cover), join re-raises it here — it must not
+            # abort teardown, or the spinner thread leaks and keeps waking
+            # forever.
+            @render_thread&.join
+          rescue => e
+            Taski::Logging.warn(
+              Taski::Logging::Events::OBSERVER_ERROR,
+              observer_class: self.class.name,
+              method: "render_loop",
+              error_message: e.message
+            )
+          ensure
+            @render_thread = nil
+            stop_spinner_timer
+          end
         end
 
         # Check if output is a TTY

--- a/lib/taski/progress/layout/simple.rb
+++ b/lib/taski/progress/layout/simple.rb
@@ -83,6 +83,9 @@ module Taski
             stop_render_loop
             @output.print "\e[?25h"  # Show cursor
             render_final
+          rescue IOError, SystemCallError
+            # The terminal is gone — there is nothing left to restore or render
+            # to. Contain the error so on_stop still flushes queued messages.
           end
 
           private

--- a/lib/taski/progress/layout/tree/live.rb
+++ b/lib/taski/progress/layout/tree/live.rb
@@ -50,6 +50,9 @@ module Taski
             stop_render_loop
             @output.print "\e[?25h" # Show cursor
             render_final
+          rescue IOError, SystemCallError
+            # The terminal is gone — there is nothing left to restore or render
+            # to. Contain the error so on_stop still flushes queued messages.
           end
 
           private

--- a/test/test_layout_tree_live.rb
+++ b/test/test_layout_tree_live.rb
@@ -109,6 +109,84 @@ class TestLayoutTreeLive < Minitest::Test
     assert_includes @output.string, "└──"
   end
 
+  # ========================================
+  # Render-thread death must not leak resources
+  # ========================================
+  # If the terminal goes away mid-run (IOError/EPIPE in the render loop), the
+  # render thread dies with that exception. Thread#join re-raises it, which
+  # used to abort handle_stop BEFORE stop_spinner_timer and the cursor
+  # restore — leaking a perpetually-waking spinner thread and leaving the
+  # user's cursor hidden.
+
+  # A TTY-like output that starts failing after a given number of writes,
+  # optionally healing afterwards. Records every attempted write.
+  class FlakyOutput
+    attr_reader :writes
+
+    def initialize(fail_on: nil, fail_count: 1_000_000)
+      @writes = []
+      @count = 0
+      @fail_on = fail_on
+      @failures_left = fail_count
+    end
+
+    def record(str)
+      @writes << str.to_s
+      @count += 1
+      if @fail_on && @count >= @fail_on && @failures_left > 0
+        @failures_left -= 1
+        raise IOError, "stream closed"
+      end
+    end
+
+    def print(*args) = args.each { |a| record(a) }
+
+    def puts(*args) = (args.empty? ? record("\n") : args.each { |a| record(a) })
+
+    def write(*args) = args.each { |a| record(a) }
+
+    def flush
+    end
+
+    def tty? = true
+
+    def winsize = [24, 80]
+  end
+
+  def test_render_thread_death_does_not_leak_the_spinner_thread
+    # The hide-cursor write succeeds; everything after (the render loop's
+    # writes) raises permanently — the terminal died mid-run.
+    output = FlakyOutput.new(fail_on: 2)
+    layout = Taski::Progress::Layout::Tree::Live.new(output: output)
+    layout.context = mock_execution_facade(root_task_class: stub_task_class("DyingTTY"))
+    layout.on_ready
+    layout.on_start
+    sleep 0.25 # let the render thread wake and die on the dead output
+
+    layout.on_stop # must not raise (join used to re-raise the IOError)
+
+    timer = layout.instance_variable_get(:@spinner_timer)
+    refute layout.instance_variable_get(:@spinner_running),
+      "spinner must be stopped even when the render thread died"
+    refute timer&.alive?, "spinner thread must not keep waking forever"
+  end
+
+  def test_cursor_restore_is_attempted_after_render_thread_death
+    # Fail exactly once (killing the render thread), then heal — the terminal
+    # came back, so the cursor restore must reach it.
+    output = FlakyOutput.new(fail_on: 2, fail_count: 1)
+    layout = Taski::Progress::Layout::Tree::Live.new(output: output)
+    layout.context = mock_execution_facade(root_task_class: stub_task_class("FlakyTTY"))
+    layout.on_ready
+    layout.on_start
+    sleep 0.25
+
+    layout.on_stop
+
+    assert_includes output.writes, "\e[?25h",
+      "the cursor must be restored once the output is writable again"
+  end
+
   private
 
   def stub_task_class(name)


### PR DESCRIPTION
## Bug

If the terminal goes away mid-run (closed stream, EPIPE — e.g. piping to a pager that exits), the render thread dies with an `IOError`. `Thread#join` **re-raises** that exception inside `stop_render_loop`, aborting `handle_stop` before `stop_spinner_timer` and the cursor restore:

- a perpetually-waking **spinner thread leaks** per occurrence (later `start_spinner_timer` calls see it alive and return early — it is never reclaimed),
- the user's **cursor stays hidden** (`\e[?25l` printed, `\e[?25h` never),
- queued `Taski.message` output is dropped,
- and the run reports success, because observer dispatch swallows the re-raise.

(Repro from the adversarial review: a tty output raising `IOError` after 2 writes → `Thread.list` 1→2, `@spinner_timer.alive? == true` a second after the run, reused-but-dead on the next run, restore never written.)

## Fix (layered)

1. `render_loop` rescues `IOError`/`SystemCallError` and exits cleanly — the terminal is gone, rendering is pointless.
2. `stop_render_loop` contains any join re-raise (logged as `OBSERVER_ERROR`) and stops the spinner in an `ensure` — teardown can no longer be skipped, whatever killed the thread.
3. `Tree::Live` / `Simple` `handle_stop` contain `IOError`/`SystemCallError` around the cursor restore + final render, so `on_stop` still flushes queued messages even when the output is dead.

## Tests

Two Tree::Live tests with a scripted flaky-TTY output (both RED on master): the spinner thread is stopped after the render thread dies on a permanently-dead output, and the cursor restore reaches an output that heals after a transient failure.

`rake test` 782 / 0, `rake standard` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)