### PR TITLE
Fix documentation drift: exports mechanism, workers:, clean_on_failure:, args scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ end
 
 ### Custom Export Methods
 
-By default, `exports` generates a reader that returns the instance variable (e.g., `exports :value` reads `@value`). You can override this by defining your own instance method with the same name:
+By default, an exported name reads the instance variable of the same name (e.g., `exports :value` reads `@value`). Exports are resolved lazily via `method_missing` — no reader method is actually defined, so an export can never shadow an existing method (the name answers to `respond_to?` but does not appear in `.methods`; use `exported_methods` for introspection). If you define your own instance method with the same name, it takes precedence:
 
 **Fixed values** — no computation needed in `run`:
 
@@ -249,16 +249,21 @@ end
 # Pass options when running
 DeployTask.run(args: { env: "production", debug: true })
 
+# Control parallelism (workers: 1 runs sequentially — useful for debugging)
+DeployTask.run(args: { env: "production" }, workers: 4)
+
 # Args can also be passed to exported class methods
 Config.timeout(args: { env: "test" })
 ```
 
 **Note:** `args:` is only accepted at the top-level call that starts an execution. If `args:` is passed to a dependency access inside a running task (e.g., `DepTask.value(args: {...})`), the args are ignored and a warning is emitted.
 
-Args API (user-defined options):
-- `Taski.args[:key]` - Get option value (nil if not set)
+Args API (user-defined options, available inside a running execution):
+- `Taski.args[:key]` - Get option value (nil if the key is not set)
 - `Taski.args.fetch(:key, default)` - Get with default value
 - `Taski.args.key?(:key)` - Check if option exists
+
+**Note:** `Taski.args` and `Taski.env` are per-execution state: outside a running execution they are `nil` (so `Taski.args[:key]` would raise `NoMethodError`), and concurrent executions each see their own values.
 
 Env API (execution environment):
 - `Taski.env.working_directory` - Execution directory
@@ -383,6 +388,10 @@ DatabaseSetup.run_and_clean
 DatabaseSetup.run_and_clean do
   deploy(DatabaseSetup.connection)
 end
+
+# By default, clean is SKIPPED when run fails. Opt in to release resources
+# (temp files, connections) even on failure:
+DatabaseSetup.run_and_clean(clean_on_failure: true)
 ```
 
 See [docs/GUIDE.md](docs/GUIDE.md#lifecycle-management) for details.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -179,6 +179,16 @@ WebServer.run_and_clean
 # => Database disconnected
 ```
 
+### Failure Semantics
+
+By default, clean is **skipped** when the run phase fails — the failure propagates immediately. Pass `clean_on_failure: true` to release resources (temp files, connections) even when run fails:
+
+```ruby
+WebServer.run_and_clean(clean_on_failure: true)
+```
+
+If clean itself fails after a successful run, the clean error propagates; if both phases fail, the original run error takes precedence and the clean failure is logged.
+
 ### run_and_clean with Block
 
 Use a block to execute code between run and clean phases. This is useful when you need to use exported values before cleanup:


### PR DESCRIPTION
## Verified doc-vs-code gaps (all confirmed by execution probes in the adversarial review)

1. **README: "exports generates a reader" is stale** — since the method_missing refactor, no reader method is defined: the name answers `respond_to?` but does not appear in `.methods` (probe: `respond_to?(:foo) == true`, `methods.include?(:foo) == false`). Reworded to describe the real mechanism and its benefit (an export can never shadow an existing method), pointing at `exported_methods` for introspection.
2. **`workers:` and `clean_on_failure:` documented nowhere user-facing** — both public kwargs existed only as YARD comments (grep across README/GUIDE/examples: zero hits). `workers:` joins the run example (with the `workers: 1` sequential-debugging tip); the README lifecycle section and a new GUIDE "Failure Semantics" section document that **clean is skipped on run failure by default**, `clean_on_failure: true` opts in, and the run error takes precedence when both phases fail (matches `run_clean_phase`).
3. **`Taski.args` scope was misleading** — "`Taski.args[:key]` - Get option value (nil if not set)" reads as if it works anywhere, but outside a running execution `Taski.args` itself is `nil`, so the call raises `NoMethodError` (probe-confirmed). Documented the per-execution (fiber-local) scope and concurrent isolation.

Docs only — no code changes. `rake test` 780 / 0, `rake standard` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)