### PR TITLE
Document skipped-task revival as a legal transition; pin it with a test

### DIFF
--- a/lib/taski/execution/scheduler.rb
+++ b/lib/taski/execution/scheduler.rb
@@ -10,7 +10,15 @@ module Taski
     #
     # Run phase:   pending → running → completed | failed
     #              pending → skipped (when a dependency fails)
+    #              skipped → running (revival — see below)
     # Clean phase: pending → running → completed
+    #
+    # :skipped is advisory bookkeeping, not an execution barrier. Under the
+    # Fiber pull model a task marked skipped (because a dependency failed) can
+    # still be requested later by a still-running task via NeedDep — it then
+    # runs normally and reaches completed/failed. Observers may therefore see
+    # skipped → running → completed for the same task within one execution;
+    # this is a legal, intended sequence.
     #
     # == Responsibilities
     #
@@ -160,7 +168,10 @@ module Taski
         @task_states.select { |_, state| state == STATE_PENDING }.keys
       end
 
-      # Mark a task as skipped (never executed). Only transitions from pending.
+      # Mark a task as skipped (not independently scheduled). Only transitions
+      # from pending. Advisory, not terminal: a still-running task can later
+      # request this task via NeedDep, reviving it (skipped → running) — see
+      # the class-level State Transitions note.
       #
       # @param task_class [Class] The task class to mark as skipped
       # @return [Boolean] true if the state was changed

--- a/lib/taski/execution/task_observer.rb
+++ b/lib/taski/execution/task_observer.rb
@@ -16,6 +16,15 @@ module Taski
     # - on_task_updated(task_class, previous_state:, current_state:, phase:, timestamp:)
     # - on_group_started(task_class, group_name, phase:, timestamp:)
     # - on_group_completed(task_class, group_name, phase:, timestamp:)
+    #
+    # == Note on :skipped
+    #
+    # :skipped means "not independently scheduled", not "will never run". When
+    # a dependency fails, its pending dependents are reported :skipped — but a
+    # still-running task may later request one of them (Fiber pull model), in
+    # which case it runs normally. Observers must tolerate the sequence
+    # skipped → running → completed/failed for the same task within one
+    # execution.
     class TaskObserver
       attr_accessor :context
 

--- a/test/fixtures/skip_revival_tasks.rb
+++ b/test/fixtures/skip_revival_tasks.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "taski"
+
+# Fixtures for the skipped-task revival contract: a task reported :skipped
+# (because a dependency failed) can later be requested by a still-running
+# task via the Fiber pull model — it then runs normally. The sequence
+# skipped → running → completed is legal and pinned by test_skip_revival.rb.
+module SkipRevivalFixtures
+  # Fails quickly, triggering the skip cascade for its dependents.
+  class ReviveFailLeaf < Taski::Task
+    exports :value
+
+    def run
+      sleep 0.05
+      raise "fast fail"
+    end
+  end
+
+  # Statically depends on ReviveFailLeaf (the branch read is a graph edge) so
+  # the skip cascade marks it skipped — but at runtime the branch is never
+  # taken, so when revived it completes without touching the failed dep.
+  class ReviveShared < Taski::Task
+    exports :value
+
+    def run
+      @value = "shared"
+      if @value.empty?
+        x = ReviveFailLeaf.value
+        @extra = "never: #{x}"
+      end
+      @value
+    end
+  end
+
+  # Reads ReviveShared only AFTER the cutoff (the bare sleep), long after the
+  # skip cascade ran — this pull is what revives the skipped task.
+  class ReviveSlowRequester < Taski::Task
+    exports :value
+
+    def run
+      sleep 0.6
+      @value = "req: #{ReviveShared.value}"
+    end
+  end
+
+  class ReviveRoot < Taski::Task
+    exports :value
+
+    def run
+      f = ReviveFailLeaf.value
+      r = ReviveSlowRequester.value
+      @hold = f
+      @value = "root: #{r}"
+    end
+  end
+end

--- a/test/test_skip_revival.rb
+++ b/test/test_skip_revival.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "timeout"
+require_relative "fixtures/skip_revival_tasks"
+
+# Characterization of the documented :skipped contract (see Scheduler and
+# TaskObserver docs): :skipped means "not independently scheduled", NOT "will
+# never run". A still-running task that requests a skipped task via the Fiber
+# pull model revives it — observers see skipped → running → completed for the
+# same task within one execution, and that sequence is legal.
+class TestSkipRevival < Minitest::Test
+  def setup
+    Taski::Task.reset! if defined?(Taski::Task)
+    Taski::StaticAnalysis::StartDepAnalyzer.clear_cache!
+  end
+
+  def test_a_skipped_task_pulled_by_a_running_task_is_revived
+    root_class = SkipRevivalFixtures::ReviveRoot
+
+    events = []
+    observer = Object.new
+    observer.define_singleton_method(:on_task_updated) do |tc, current_state:, **_|
+      events << [tc, current_state]
+    end
+    observer.define_singleton_method(:on_ready) {}
+    observer.define_singleton_method(:on_start) {}
+    observer.define_singleton_method(:on_stop) {}
+
+    registry = Taski::Execution::Registry.new
+    facade = Taski::Execution::ExecutionFacade.new(root_task_class: root_class)
+    facade.add_observer(observer)
+
+    executor = Taski::Execution::Executor.new(
+      registry: registry,
+      execution_facade: facade,
+      worker_count: 4
+    )
+
+    error = nil
+    Timeout.timeout(15) do
+      error = assert_raises(Taski::AggregateError) { executor.execute(root_class) }
+    end
+
+    shared = SkipRevivalFixtures::ReviveShared
+    skipped_at = events.index([shared, :skipped])
+    running_at = events.rindex([shared, :running])
+    completed_at = events.index([shared, :completed])
+
+    refute_nil skipped_at, "the dependent of the failed leaf must first be reported skipped"
+    refute_nil running_at, "the pull from the still-running requester must revive it"
+    refute_nil completed_at, "the revived task must complete"
+    assert_operator skipped_at, :<, running_at,
+      "the legal revival sequence is skipped -> running -> completed"
+    assert_operator running_at, :<, completed_at
+
+    # The revival is consistent end to end: the requester observed the revived
+    # task's real value, and the failure report contains only the real failure.
+    failures = error.errors.map(&:task_class)
+    assert_includes failures, SkipRevivalFixtures::ReviveFailLeaf
+    refute_includes failures, shared, "the revived task completed — it must not be reported failed"
+  end
+end


### PR DESCRIPTION
## The behavior

A task reported `:skipped` (because a dependency failed) can later be **revived**: if a still-running task requests it via the Fiber pull model, it runs normally and completes. Observers see `skipped → running → completed` for the same task within one execution. An adversarial review reproduced this deterministically (5/5) and flagged the contradictory observer sequence; the state-transition docs listed no exit from `skipped`.

## The decision: keep it, and make it a contract

Under the pull model, *requested means needed* — refusing the request would deadlock the requester, and deferring skip notifications to end-of-run would destroy the immediate skip-cascade ordering (which the suite now pins). So the transition is correct; what was missing was honesty about it:

- **Scheduler** state-transition docs gain `skipped → running (revival)` and define `:skipped` as *advisory bookkeeping* ("not independently scheduled"), not an execution barrier — matching the comment already shipped in the dead-code-removal PR.
- **TaskObserver** docs tell observer authors to tolerate the sequence.
- **`test_skip_revival.rb`** pins it end to end: the dependent of a fast-failing leaf is reported skipped (~50ms), revived by a slow requester's pull (~650ms), completes with its real value observed by the requester, and the `AggregateError` contains only the real failure — the revived task is not mis-reported.

Docs + characterization test only; no behavior change. `rake test` 781 / 0, `rake standard` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified task state transition semantics, specifically that skipped tasks may be revived if later requested by running dependents.

* **Tests**
  * Added test fixtures and comprehensive test coverage for skip-revival scenarios within a single execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->