### PR TITLE
Fix tree rendering of shared dependencies (diamond graphs)

### DIFF
--- a/lib/taski/progress/layout/tree/structure.rb
+++ b/lib/taski/progress/layout/tree/structure.rb
@@ -24,8 +24,7 @@ module Taski
 
           def init_tree_structure
             @tree_nodes = {}
-            @node_depths = {}
-            @node_is_last = {}
+            @node_prefixes = {}
           end
 
           def build_ready_tree
@@ -64,9 +63,17 @@ module Taski
 
             task_class = node[:task_class]
             @tasks[task_class] ||= new_task_progress
-            @tree_nodes[task_class] = node
-            @node_depths[task_class] = depth
-            @node_is_last[task_class] = {is_last: is_last, ancestors_last: ancestors_last.dup}
+            @tree_nodes[task_class] ||= node
+
+            # A shared dependency is registered once per occurrence in the
+            # tree. The prefix belongs to the OCCURRENCE (stored on the node),
+            # not to the task class — a class-keyed prefix would be clobbered
+            # by the last occurrence and corrupt every earlier row. The
+            # class-keyed map keeps only the FIRST occurrence, as the one
+            # canonical prefix for per-event output lines.
+            prefix = compute_tree_prefix(depth: depth, is_last: is_last, ancestors_last: ancestors_last)
+            node[:prefix] = prefix
+            @node_prefixes[task_class] ||= prefix
 
             children = node[:children]
             children.each_with_index do |child, index|
@@ -88,9 +95,8 @@ module Taski
           def build_node_lines(node, lines)
             return unless node
 
-            task_class = node[:task_class]
-            prefix = build_tree_prefix(task_class)
-            content = build_task_content(task_class)
+            prefix = node[:prefix] || ""
+            content = build_task_content(node[:task_class])
             lines << "#{prefix}#{content}"
 
             node[:children].each do |child|
@@ -116,15 +122,14 @@ module Taski
             end
           end
 
+          # Canonical (first-occurrence) prefix for a task class, used by
+          # per-event output lines in Tree::Event.
           def build_tree_prefix(task_class)
-            depth = @node_depths[task_class]
-            return "" if depth.nil? || depth == 0
+            @node_prefixes[task_class] || ""
+          end
 
-            last_info = @node_is_last[task_class]
-            return "" unless last_info
-
-            ancestors_last = last_info[:ancestors_last]
-            is_last = last_info[:is_last]
+          def compute_tree_prefix(depth:, is_last:, ancestors_last:)
+            return "" if depth.zero?
 
             prefix = ""
             # Skip the first ancestor (root) since root has no visual prefix
@@ -132,8 +137,7 @@ module Taski
               prefix += ancestor_is_last ? SPACE : VERTICAL
             end
 
-            prefix += is_last ? LAST_BRANCH : BRANCH
-            prefix
+            prefix + (is_last ? LAST_BRANCH : BRANCH)
           end
         end
       end

--- a/test/test_layout_tree_event.rb
+++ b/test/test_layout_tree_event.rb
@@ -283,6 +283,65 @@ class TestLayoutTreeEventPrefix < Minitest::Test
     refute_includes @output.string, "└── ⠋ RootTask"
   end
 
+  # A shared dependency (diamond: Root -> Left -> Shared, Root -> Shared)
+  # appears once per occurrence in the rendered tree — each occurrence with
+  # the prefix of ITS OWN position. Prefix data must be per-node, not keyed
+  # by task class (a later registration must not clobber an earlier one).
+  def test_render_tree_with_shared_dependency_renders_each_occurrence_with_its_own_prefix
+    shared = stub_task_class("SharedTask")
+    left = stub_task_class_with_deps("LeftTask", [shared])
+    root = stub_task_class_with_deps("RootTask", [left, shared])
+
+    ctx = mock_execution_facade(root_task_class: root)
+    @layout.context = ctx
+    @layout.on_ready
+
+    assert_equal [
+      "○ RootTask",
+      "├── ○ LeftTask",
+      "│   └── ○ SharedTask",
+      "└── ○ SharedTask"
+    ], @layout.render_tree.lines.map(&:chomp)
+  end
+
+  # Event-mode per-event lines use one canonical prefix for a shared task:
+  # its first occurrence in the tree (the position it is first printed at).
+  def test_event_output_for_shared_dependency_uses_first_occurrence_prefix
+    shared = stub_task_class("SharedTask")
+    left = stub_task_class_with_deps("LeftTask", [shared])
+    root = stub_task_class_with_deps("RootTask", [left, shared])
+
+    ctx = mock_execution_facade(root_task_class: root)
+    @layout.context = ctx
+    @layout.on_ready
+    @layout.on_start
+    @layout.on_task_updated(shared, previous_state: :pending, current_state: :running, phase: :run, timestamp: Time.now)
+    @layout.on_stop
+
+    assert_includes @output.string, "│   └── ⠋ SharedTask"
+  end
+
+  # A circular graph renders the cycle as a childless leaf occurrence. When
+  # the ROOT class reappears (Root -> A -> Root), the class-keyed node map
+  # must keep the ROOT occurrence (the first registration), not the circular
+  # leaf — otherwise build_tree_lines walks the leaf and the whole tree
+  # collapses to a single orphan line.
+  def test_render_tree_with_root_cycle_renders_full_tree_from_root_occurrence
+    a = stub_task_class("ATask")
+    root = stub_task_class_with_deps("RootTask", [a])
+    a.define_singleton_method(:cached_dependencies) { [root] }
+
+    ctx = mock_execution_facade(root_task_class: root)
+    @layout.context = ctx
+    @layout.on_ready
+
+    assert_equal [
+      "○ RootTask",
+      "└── ○ ATask",
+      "    └── ○ RootTask"
+    ], @layout.render_tree.lines.map(&:chomp)
+  end
+
   private
 
   def stub_task_class(name)


### PR DESCRIPTION
## Problem

Found while recording the theme demo for #235/#236 — **pre-existing on master** (verified byte-identical there). When a task is a shared dependency (diamond: `Root → Left → Shared` and `Root → Shared`), the rendered tree duplicates the row with a broken prefix:

```
Root                           Root
├── Left                       ├── Left
└── Shared        instead of   │   └── Shared
└── Shared                     └── Shared
```

`register_tree_nodes` keyed `depth`/`is_last`/`ancestors_last` by **task class**, so the last-registered occurrence clobbered every earlier one — all rows for that class rendered with the same prefix.

## Fix

The prefix belongs to the **occurrence**, not the class: it is computed at registration and stored on the tree node; `build_node_lines` reads it from the node. The class-keyed map keeps only the first occurrence's prefix as the one canonical prefix for `Tree::Event`'s per-event lines (a shared task runs once; its event line prints at the position it first appears in the tree).

**Second bug fixed by the same first-wins change** (found by the adversarial review): when the *root* class reappears as a circular leaf (`Root → A → Root` — `Task.tree` renders cyclic graphs by design, cycle validation only runs at execution), master clobbered the root's node with the childless circular leaf, so `build_tree_lines` walked the leaf and the whole tree collapsed to a single orphan line (`    └── Root`). Now renders the full tree with the cycle as a leaf occurrence.

Affects `render_tree` (`Task.tree`, `Tree::Live` live/final frames) and `Tree::Event` event lines.

## Tests

- Exact full-tree assertion for the diamond case
- Event-line prefix assertion for a shared task
- Exact full-tree assertion for the root-cycle case (kills the `||=` → `=` revert mutant, which previously survived the full suite)
- Suite 789 runs / 0 failures, `rake standard` clean
- Theme-independent tests — merges cleanly in either order with #235/#236

## Adversarial review

28-agent review across the three follow-up PRs: for this PR, deep diamonds / multiple shared nodes / shared subtrees / circular markers / Live lifecycle all verified correct, non-shared output byte-identical to master. 1 confirmed finding (the untested root-cycle behavior above) — folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)