### PR TITLE
Attribute deduplicated failures to the origin task, not a requester

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -83,8 +83,9 @@ begin
   AppTask.run
 rescue DatabaseTask::Error => e
   puts "Database task failed: #{e.message}"
-  # e.task_class returns DatabaseTask
-  # e.cause returns the original error
+  # e is the AggregateError that contained the DatabaseTask::Error;
+  # e.cause returns that DatabaseTask::Error (whose #task_class is
+  # DatabaseTask, and whose #cause is the original exception)
 end
 ```
 

--- a/lib/taski/execution/executor.rb
+++ b/lib/taski/execution/executor.rb
@@ -259,41 +259,64 @@ module Taski
       def raise_if_any_failures
         raise_if_any_failures_from(
           @registry.failed_wrappers,
-          error_accessor: ->(w) { w.error }
+          error_accessor: ->(w) { w.error },
+          order_accessor: ->(w) { w.failed_order || Float::INFINITY }
         )
       end
 
       def raise_if_any_clean_failures
         raise_if_any_failures_from(
           @registry.failed_clean_wrappers,
-          error_accessor: ->(w) { w.clean_error }
+          error_accessor: ->(w) { w.clean_error },
+          order_accessor: ->(w) { w.clean_failed_order || Float::INFINITY }
         )
       end
 
-      def raise_if_any_failures_from(failed_wrappers, error_accessor:)
+      def raise_if_any_failures_from(failed_wrappers, error_accessor:, order_accessor:)
         return if failed_wrappers.empty?
 
         abort_wrapper = failed_wrappers.find { |w| error_accessor.call(w).is_a?(TaskAbortException) }
         raise error_accessor.call(abort_wrapper) if abort_wrapper
 
-        failures = flatten_failures_from(failed_wrappers, error_accessor: error_accessor)
-        unique_failures = failures.uniq { |f| error_identity(f.error) }
+        # Attribute each unique error to its ORIGIN: a dependency failure
+        # re-raises the same error object in every waiter up the requester
+        # chain, and the dedup below keeps the first occurrence — so order
+        # the wrappers chronologically (in the run phase a waiter can only
+        # fail AFTER its dependency's mark_failed, so the origin stamps
+        # first; clean-phase failures have no such propagation ordering, but
+        # there a shared error object means both attributions are true).
+        # Registry order would attribute the error to whichever wrapper was
+        # created first, typically the root.
+        #
+        # Failures spliced from a nested executor's AggregateError are
+        # already origin-attributed by that executor — prefer them over a
+        # wrapper-level entry for the same error regardless of stamp order.
+        ordered = failed_wrappers.sort_by { |w| order_accessor.call(w) }
+        unique = {}
+        flatten_failures_from(ordered, error_accessor: error_accessor) do |failure, origin_attributed|
+          key = error_identity(failure.error)
+          existing = unique[key]
+          unique[key] = [failure, origin_attributed] if existing.nil? || (origin_attributed && !existing[1])
+        end
 
-        raise AggregateError.new(unique_failures)
+        raise AggregateError.new(unique.values.map(&:first))
       end
 
+      # Yields [TaskFailure, origin_attributed] for each failure entry.
+      # origin_attributed is true for failures spliced from a nested
+      # AggregateError (the nested executor already named the origin task).
       def flatten_failures_from(failed_wrappers, error_accessor:)
         output_capture = @saved_output_capture
 
-        failed_wrappers.flat_map do |wrapper|
+        failed_wrappers.each do |wrapper|
           error = error_accessor.call(wrapper)
           case error
           when AggregateError
-            error.errors
+            error.errors.each { |failure| yield failure, true }
           else
             wrapped_error = wrap_with_task_error(wrapper.task.class, error)
             output_lines = output_capture&.read(wrapper.task.class) || []
-            [TaskFailure.new(task_class: wrapper.task.class, error: wrapped_error, output_lines: output_lines)]
+            yield TaskFailure.new(task_class: wrapper.task.class, error: wrapped_error, output_lines: output_lines), false
           end
         end
       end

--- a/lib/taski/execution/task_wrapper.rb
+++ b/lib/taski/execution/task_wrapper.rb
@@ -13,6 +13,16 @@ module Taski
     class TaskWrapper
       attr_reader :task, :result, :error, :clean_error
 
+      # Monotonic timestamps of when run/clean failure was recorded. In the
+      # RUN phase a dependency failure re-raises the same error object in
+      # every waiter, and a waiter can only fail AFTER its dependency's
+      # mark_failed (the notification happens-after the stamp) — so the
+      # chronologically first wrapper for a given error is its origin. The
+      # clean phase has no such propagation ordering; there the stamp only
+      # makes the failure report chronological. Used by the Executor to
+      # attribute deduplicated failures.
+      attr_reader :failed_order, :clean_failed_order
+
       STATE_PENDING = :pending
       STATE_RUNNING = :running
       STATE_COMPLETED = :completed
@@ -154,6 +164,7 @@ module Taski
         waiters_to_notify = nil
         @monitor.synchronize do
           @error = error
+          @failed_order = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           @state = STATE_FAILED
           @condition.broadcast
           waiters_to_notify = @waiters.dup
@@ -193,6 +204,7 @@ module Taski
       def mark_clean_failed(error)
         @monitor.synchronize do
           @clean_error = error
+          @clean_failed_order = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           @clean_state = STATE_FAILED
           @clean_condition.broadcast
         end

--- a/test/fixtures/attribution_tasks.rb
+++ b/test/fixtures/attribution_tasks.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "taski"
+
+# Fixtures for AggregateError attribution: a dependency failure propagates up
+# the requester chain (every waiter re-raises the same error object), and the
+# deduplicated TaskFailure must name the ORIGIN task — the one whose run
+# raised — not whichever requester happened to be registered first.
+module AttributionFixtures
+  # The origin: its own run raises.
+  class OriginFail < Taski::Task
+    exports :value
+
+    def run
+      raise "origin boom"
+    end
+  end
+
+  # Re-raises OriginFail's error when the pull fails.
+  class MiddleRequester < Taski::Task
+    exports :value
+
+    def run
+      @value = "mid: #{OriginFail.value}"
+    end
+  end
+
+  class ChainRoot < Taski::Task
+    exports :value
+
+    def run
+      @value = "root: #{MiddleRequester.value}"
+    end
+  end
+
+  # Two independent origins read by one root — the GUIDE Error Handling shape.
+  class IndependentFailA < Taski::Task
+    exports :value
+
+    def run
+      raise "A failed"
+    end
+  end
+
+  class IndependentFailB < Taski::Task
+    exports :value
+
+    def run
+      raise "B failed"
+    end
+  end
+
+  class FanInRoot < Taski::Task
+    exports :value
+
+    def run
+      a = IndependentFailA.value
+      b = IndependentFailB.value
+      @value = "#{a}#{b}"
+    end
+  end
+
+  # Nested executor: the outer task's body starts a whole inner execution.
+  # The inner executor raises an AggregateError already attributed to
+  # InnerLeaf; the outer executor splices those failures through.
+  class InnerLeaf < Taski::Task
+    exports :value
+
+    def run
+      raise "inner boom"
+    end
+  end
+
+  class InnerRoot < Taski::Task
+    exports :value
+
+    def run
+      @value = "inner: #{InnerLeaf.value}"
+    end
+  end
+
+  class NestedOuter < Taski::Task
+    exports :value
+
+    def run
+      # Bare call statement (not an assignment): phase-1 static analysis stops
+      # here, so InnerRoot is not prestarted by the outer execution — it runs
+      # purely as a nested executor inside this body.
+      InnerRoot.run
+      @value = "outer done"
+    end
+  end
+end

--- a/test/test_failure_attribution.rb
+++ b/test/test_failure_attribution.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "timeout"
+require_relative "fixtures/attribution_tasks"
+
+# AggregateError must attribute each unique error to its ORIGIN task (the one
+# whose run raised). A dependency failure re-raises the same error object in
+# every waiter up the requester chain; deduplication must keep the origin's
+# TaskFailure, not a requester's. This is the contract the GUIDE's Error
+# Handling section documents ("- DatabaseTask: Database connection failed",
+# "rescue DatabaseTask::Error").
+class TestFailureAttribution < Minitest::Test
+  def setup
+    Taski::Task.reset! if defined?(Taski::Task)
+    Taski::StaticAnalysis::StartDepAnalyzer.clear_cache!
+  end
+
+  def test_propagated_failure_is_attributed_to_the_origin_task
+    error = Timeout.timeout(15) do
+      assert_raises(Taski::AggregateError) { AttributionFixtures::ChainRoot.run }
+    end
+
+    assert_equal 1, error.errors.size,
+      "one underlying error must yield one TaskFailure"
+    failure = error.errors.first
+    assert_equal AttributionFixtures::OriginFail, failure.task_class,
+      "the failure must name the task whose run raised, not a requester"
+    assert_equal "origin boom", failure.error.message
+    assert_kind_of AttributionFixtures::OriginFail::Error, failure.error,
+      "the error must be wrapped as the ORIGIN's task-specific Error class"
+  end
+
+  def test_guide_documented_task_specific_rescue_matches_the_origin
+    matched = false
+    Timeout.timeout(15) do
+      AttributionFixtures::ChainRoot.run
+    rescue AttributionFixtures::OriginFail::Error
+      matched = true
+    end
+
+    assert matched,
+      "rescue OriginFail::Error must match the AggregateError (AggregateAware ===) — the GUIDE-documented pattern"
+  end
+
+  def test_independent_failures_are_each_attributed_to_their_own_task
+    error = Timeout.timeout(15) do
+      assert_raises(Taski::AggregateError) { AttributionFixtures::FanInRoot.run }
+    end
+
+    classes = error.errors.map(&:task_class)
+    assert_includes classes, AttributionFixtures::IndependentFailA
+    assert_includes classes, AttributionFixtures::IndependentFailB
+    refute_includes classes, AttributionFixtures::FanInRoot,
+      "the requester only re-raised its dependencies' errors — it must not appear"
+    assert_equal 2, error.errors.size
+  end
+
+  def test_nested_executor_failures_keep_the_inner_origin_attribution
+    error = Timeout.timeout(15) do
+      assert_raises(Taski::AggregateError) { AttributionFixtures::NestedOuter.run }
+    end
+
+    # The inner executor attributed the failure to InnerLeaf; the outer
+    # executor splices those failures through and must not re-attribute them
+    # to the outer task that carried the nested AggregateError.
+    assert_equal 1, error.errors.size
+    assert_equal AttributionFixtures::InnerLeaf, error.errors.first.task_class
+    assert_kind_of AttributionFixtures::InnerLeaf::Error, error.errors.first.error
+  end
+end


### PR DESCRIPTION
## Problem

Found while recording the theme demo: the failure summary attributed a dependency's error to the *requester chain end* instead of the task that actually raised. **Pre-existing on master**, and it breaks behavior the GUIDE explicitly documents.

Probe (the GUIDE's own Error Handling example shape), before:

```
2 task(s) in AggregateError:
  - AppTask: Database connection failed (AppTask::Error)   ← origin is DatabaseTask
  - CacheTask: Cache connection failed (CacheTask::Error)
rescue DatabaseTask::Error => DID NOT MATCH
```

The GUIDE documents `- DatabaseTask: Database connection failed` and the task-specific rescue pattern `rescue DatabaseTask::Error` — which **silently failed to match** for propagated failures, because the deduplicated error was wrapped as `AppTask::Error`.

## Cause

A dependency failure re-raises the same error object in every waiter up the requester chain; the executor dedupes by error identity keeping the **first occurrence in registry order** — typically the root, whose wrapper is created first.

## Fix

- `TaskWrapper` stamps `Process.clock_gettime(CLOCK_MONOTONIC)` when recording a run/clean failure. In the run phase a waiter can only fail *after* its dependency's `mark_failed` (the notification happens-after the stamp), so the chronologically first wrapper for an error is its origin. The executor sorts failed wrappers by the stamp before dedup.
- **Nested executors** (from the adversarial review): failures spliced from a nested `AggregateError` are already origin-attributed by the inner executor — the dedup now *prefers* them over a wrapper-level entry for the same error regardless of stamp order.
- The happens-before guarantee is documented as **run-phase-only** (clean failures have no propagation ordering; there the stamp just makes the report chronological, and a shared error object means both candidate attributions are true).
- Also corrects a GUIDE comment in the same section that claimed `e.task_class` works on the rescued object (`e` is the `AggregateError`; the task-specific error is reached via `e.cause`) — verified inaccurate on master.

After:

```
2 task(s) in AggregateError:
  - DatabaseTask: Database connection failed (DatabaseTask::Error)
  - CacheTask: Cache connection failed (CacheTask::Error)
rescue DatabaseTask::Error => MATCHED
```

## Tests

`test_failure_attribution.rb` with fixture tasks (per CLAUDE.md): three-task requester chain attributes to the leaf origin + `OriginFail::Error` matches via `AggregateAware ===`; two independent failures each attribute to their own task; a nested executor's inner attribution survives the outer aggregate. The existing skip-revival assertion is strengthened by this change.

Suite 790 runs / 0 failures, `rake standard` clean.

## Adversarial review

28-agent review across the three follow-up PRs: for this PR, origin attribution verified under nested-executor, abort, clean, late-failure and stress probes; both ordering mutants killed outright by the new tests. Confirmed findings (nested-aggregate preference, run-phase-only documentation) folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)