### PR TITLE
Re-adopt the output capture for the clean phase of run_and_clean

### DIFF
--- a/lib/taski/progress/layout/base.rb
+++ b/lib/taski/progress/layout/base.rb
@@ -38,6 +38,7 @@ module Taski
           @start_time = nil
           @root_task_class = nil
           @output_capture = nil
+          @display_facade = nil
           @message_queue = []
           @group_start_times = {}
           @spinner_index = 0
@@ -50,10 +51,23 @@ module Taski
 
         # Event 1: Facade is ready (root task set, output capture available).
         # Pulls root_task_class and output_capture from context.
-        # Only sets root_task_class once (prevents nested executor overwrite).
+        #
+        # root_task_class and the tree build (handle_ready) happen once — a
+        # nested executor must not overwrite the displayed root. The output
+        # capture, however, is re-adopted when the owning execution re-readies
+        # on the SAME facade: the clean phase of run_and_clean tears down the
+        # run-phase output router and builds a fresh one, and the status line
+        # must follow it or it reads the dead run-phase router during clean.
+        # The facade-identity guard means a nested execution (a different
+        # facade) cannot retarget the display's capture, while normal nesting
+        # (which reuses the current facade and router) is a harmless no-op.
         def on_ready
           @monitor.synchronize do
-            return if @root_task_class
+            if @root_task_class
+              @output_capture = @context.output_capture if @context.equal?(@display_facade)
+              return
+            end
+            @display_facade = @context
             @root_task_class = @context&.root_task_class
             @output_capture = @context&.output_capture
             handle_ready

--- a/test/fixtures/clean_capture_tasks.rb
+++ b/test/fixtures/clean_capture_tasks.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "taski"
+
+# Fixtures for the clean-phase output-capture contract: run_and_clean shares
+# one ExecutionFacade across both phases, but each phase sets up and tears
+# down its own output router. The layout must re-adopt the clean-phase router
+# at the clean-phase on_ready (see test_clean_phase_output_capture.rb).
+module CleanCaptureFixtures
+  class Leaf < Taski::Task
+    exports :value
+
+    def run
+      puts "run output"
+      sleep 0.3
+      @value = 1
+    end
+
+    def clean
+      puts "clean output"
+      # Give the router's async poll thread time to drain the line before the
+      # clean-completed event, so the test reads it deterministically (mirrors
+      # the run phase; the poll interval is ~0.1s).
+      sleep 0.3
+    end
+  end
+end

--- a/test/test_clean_phase_output_capture.rb
+++ b/test/test_clean_phase_output_capture.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "taski/progress/layout/base"
+require_relative "fixtures/clean_capture_tasks"
+
+# End-to-end pin for the clean-phase output-capture contract through the real
+# executor: run_and_clean reuses ONE ExecutionFacade across both phases, but
+# the run phase tears down its output router and the clean phase builds a
+# fresh one. The display layer must re-adopt the clean-phase router so the
+# status line shows live clean-phase output instead of reading the dead
+# run-phase router.
+class TestCleanPhaseOutputCapture < Minitest::Test
+  # A layout that records, at every on_ready and every render, which output
+  # router it currently holds and what last line that router reports for the
+  # task. (Non-TTY so it never starts a render thread; we read state directly.)
+  class RecordingLayout < Taski::Progress::Layout::Base
+    def self.build(output: $stderr, theme: nil)
+      new(output: output, theme: theme)
+    end
+
+    attr_reader :ready_captures, :clean_last_lines
+
+    def initialize(output: $stderr, theme: nil)
+      super
+      @ready_captures = []
+      @clean_last_lines = []
+    end
+
+    def on_ready
+      super
+      @monitor.synchronize { @ready_captures << @output_capture }
+    end
+
+    # Records the clean-phase output the router exposes as it completes a task.
+    def handle_task_update(task_class, current_state, phase)
+      if phase == :clean && current_state == :completed
+        @clean_last_lines << @output_capture&.last_line_for(task_class)
+      end
+      super
+    end
+  end
+
+  def setup
+    Taski::Task.reset! if defined?(Taski::Task)
+    Taski::StaticAnalysis::StartDepAnalyzer.clear_cache!
+    @saved = Taski.progress_display
+    Taski.progress.layout = RecordingLayout
+  end
+
+  def teardown
+    Taski.reset_progress_display!
+  end
+
+  def test_clean_phase_router_is_adopted_and_shows_clean_output
+    CleanCaptureFixtures::Leaf.run_and_clean
+
+    layout = Taski.progress_display
+    refute_nil layout, "the recording layout must be the active display"
+
+    # on_ready fires once per phase on the shared facade; the run-phase router
+    # and the clean-phase router are distinct objects, both real.
+    captures = layout.ready_captures.compact
+    assert_equal 2, captures.size, "expected an on_ready for both run and clean phases"
+    refute_same captures[0], captures[1],
+      "the clean phase rebuilds the router — the layout must adopt the new one"
+
+    # The adopted clean-phase router reports the clean-phase output line, not a
+    # stale run-phase line (the bug: the layout kept reading the dead run router).
+    assert_includes layout.clean_last_lines.compact, "clean output",
+      "the status line must read the clean-phase router's live output"
+    refute_includes layout.clean_last_lines.compact, "run output",
+      "the clean phase must not read the dead run-phase router"
+  end
+end

--- a/test/test_layout_base.rb
+++ b/test/test_layout_base.rb
@@ -260,6 +260,40 @@ class TestLayoutBase < Minitest::Test
     refute_includes @output.string, "Integer"
   end
 
+  # The clean phase of run_and_clean re-readies on the SAME facade after it
+  # tore down the run-phase output router and built a fresh one. The layout
+  # must re-adopt the fresh router, or the status line keeps reading the dead
+  # run-phase router during clean (showing stale/blank output).
+  def test_on_ready_readopts_capture_when_same_facade_re_readies
+    facade = stub_facade(root: String, capture: :run_router)
+    @layout.context = facade
+    @layout.on_ready
+    assert_equal :run_router, current_output_capture
+
+    facade.define_singleton_method(:output_capture) { :clean_router }
+    @layout.on_ready
+
+    assert_equal :clean_router, current_output_capture,
+      "the fresh clean-phase router must be re-adopted"
+    assert_equal String, @layout.instance_variable_get(:@root_task_class),
+      "the root task must not change across phases"
+  end
+
+  # A nested execution runs on a DIFFERENT facade. It does not own the
+  # display, so a re-ready from it must not retarget the capture (nor rebuild
+  # the tree / overwrite the root — the existing once-guard).
+  def test_on_ready_does_not_retarget_capture_for_a_different_facade
+    @layout.context = stub_facade(root: String, capture: :run_router)
+    @layout.on_ready
+
+    @layout.context = stub_facade(root: Integer, capture: :nested_router)
+    @layout.on_ready
+
+    assert_equal :run_router, current_output_capture,
+      "a different (nested) facade must not retarget the display's capture"
+    assert_equal String, @layout.instance_variable_get(:@root_task_class)
+  end
+
   # === Message queue ===
 
   def test_queue_message_stores_message
@@ -315,6 +349,21 @@ class TestLayoutBase < Minitest::Test
     end
     threads.each(&:join)
     # No error raised
+  end
+
+  private
+
+  # A minimal facade stub whose output_capture can be swapped to simulate a
+  # phase rebuilding its router.
+  def stub_facade(root:, capture:)
+    facade = Object.new
+    facade.define_singleton_method(:root_task_class) { root }
+    facade.define_singleton_method(:output_capture) { capture }
+    facade
+  end
+
+  def current_output_capture
+    @layout.instance_variable_get(:@output_capture)
   end
 end
 


### PR DESCRIPTION
## Problem

Flagged during the #237–#239 review and confirmed here with instrumentation: during the **clean** phase of `run_and_clean`, the Simple status line shows stale run-phase output (or blank) instead of live clean output.

`run_and_clean` reuses **one** `ExecutionFacade` across both phases, but each phase's `Executor` (`execute` / `execute_clean`) sets up and tears down its **own** `TaskOutputRouter`. The layout grabs the run-phase router at the run-phase `on_ready`; then `on_ready`'s `return if @root_task_class` once-guard means the clean phase's fresh router — built *after* the run router was torn down — is never adopted. The layout reads the dead run router for the whole clean phase.

Instrumented trace (before), `ctx` = facade, `ctx_cap` = facade's current router:

```
[on_ready] root="CleanGroupTask" cap 4->176 ctx=184 ctx_cap=176   # run: layout adopts 176
[on_ready] root="CleanGroupTask" cap 176->176 ctx=184 ctx_cap=200 # clean: SAME facade, fresh router 200, layout STUCK on 176
```

## Fix

The once-guard exists to stop a **nested executor** from overwriting the displayed root / rebuilding the tree — not to freeze the output capture. Re-adopting the capture is safe and necessary when the **same facade** re-readies (the clean phase).

`on_ready` now refreshes `@output_capture` whenever the readying context is the facade that owns the display (recorded as `@display_facade` on the first ready), and keeps `root_task_class` + `handle_ready` behind the once-guard. The discriminator is facade identity, established by probing the real lifecycle:

- **Clean phase**: same facade, fresh router → re-adopt ✓
- **Nested execution**: `fresh_wrapper` reuses `ExecutionFacade.current`, so it runs on the *current* facade and router → refresh is a no-op (verified: nested `on_ready` shows identical `ctx`/`ctx_cap` to its parent)
- **Unrelated facade**: cannot retarget the display's capture

After:

```
[on_ready] ... cap 176->200 ctx=184 ctx_cap=200   # clean: router 200 adopted
status frame: ⠦ [1/1] CleanGroupTask | CLEAN removing artifact
```

## Tests

- Component (`test_layout_base.rb`): same-facade re-ready adopts the new router and keeps the root; a different facade does **not** retarget the capture (nor the root — the once-guard).
- End-to-end (`test_clean_phase_output_capture.rb`, fixture tasks per CLAUDE.md): `run_and_clean` through the real executor adopts two distinct routers, and the clean-phase status line reads the clean-phase output, not the dead run router. Deterministic across repeated runs.

Suite 789 runs / 0 failures, `rake standard` clean. Off master, theme-independent — merges cleanly in any order with the other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed output display to correctly show active-phase task output during execution.

* **Tests**
  * Added comprehensive tests for clean-phase output capture behavior.
  * Added tests validating display facade handling in progress layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->