### PR TITLE
Add data themes: shareable YAML progress themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,22 @@ Taski.progress.layout = Taski::Progress::Layout::Log     # Log output (CI/logs)
 Taski.progress_display = nil                             # Disable progress output entirely
 ```
 
+**Themes** customize how each line looks — as a Ruby class (full power) or
+an inert YAML file (no code, safe to share):
+
+```ruby
+class MyTheme < Taski::Progress::Theme::Detail
+  def icon_success = "🎉"
+end
+Taski.progress.theme = MyTheme
+
+# or a data theme — validated at assignment (see examples/themes/catppuccin-mocha.yml):
+Taski.progress.theme = "examples/themes/catppuccin-mocha.yml"
+```
+
+See the [guide](docs/GUIDE.md#customizing-themes) for the template methods,
+helpers, and the YAML placeholder vocabulary.
+
 ### Tree Visualization
 
 ```ruby

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -358,6 +358,125 @@ Taski.progress.layout = Taski::Progress::Layout::Log     # Log output (CI/logs)
 Taski.progress_display = nil                             # Disable progress output entirely
 ```
 
+### Customizing Themes
+
+The layout decides *what* gets rendered when; the theme decides *how each
+line looks*. There are two ways to customize a theme: a Ruby class (full
+power) or a YAML data theme (no code — safe to share and use without
+reading).
+
+#### Ruby Themes
+
+Subclass `Taski::Progress::Theme::Base` (or a shipped theme: `Default`,
+`Detail`, `Compact`, `Plain`) and override any of the 15 template methods.
+Each receives immutable render data and returns the final display string —
+plain Ruby, so conditionals, loops, and arbitrary formatting are all
+available:
+
+```ruby
+class MyTheme < Taski::Progress::Theme::Detail
+  def spinner_frames = %w[🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘]
+  def icon_success = "🎉"
+
+  # Highlight slow tasks in red
+  def task_success(task:, execution: nil)
+    part = (task.duration && task.duration >= 1000) ? red(" (#{format_duration(task.duration)})") : duration_part(task.duration)
+    "#{icon_for(task.state)} #{short_name(task.name)}#{part}"
+  end
+end
+
+Taski.progress.theme = MyTheme
+```
+
+Task-level methods (`task_pending/start/success/fail/skip`,
+`clean_start/success/fail`, `group_start/success/fail`) have the signature
+`def m(task:, execution: nil)`; execution-level methods (`execution_start/
+running/complete/fail`) have `def m(execution:, task: nil)`. The layout
+always passes both keywords.
+
+`task` is a `TaskInfo` (`name`, `state`, `duration`, `error_message`,
+`group_name`, `stdout`); `execution` is an `ExecutionInfo` (`state`, count
+tallies, `total_duration`, `root_task_name`, `task_names`, `spinner_index`).
+
+Helpers available in every theme: `short_name`, `icon_for(state)`,
+`spinner_frame(index)`, `colorize`/`red`/`green`/`yellow`/`dim`,
+`truncate_text`/`truncate_list`, `format_count`/`format_duration`, and the
+fragment helpers `duration_part`/`error_part`/`stdout_part`/`task_names_part`
+(render `" (1.2s)"`-style suffixes only when the value is present).
+
+A buggy theme cannot break a run: any exception from a theme method is
+contained by the renderer — the line renders empty and a
+`template.render_error` warning is logged. Themes must be stateless (one
+instance is shared across threads).
+
+#### Data Themes (YAML)
+
+A data theme is an inert YAML file — no code runs, so you can use themes
+from others without auditing them:
+
+```yaml
+# my-theme.yml
+schema: 1
+extends: detail            # base | default | plain | detail | compact
+
+colors:
+  green: "\e[38;2;166;227;161m"   # truecolor works
+  reset: "\e[0m"
+
+icons:
+  success: "✔"
+
+templates:
+  task_success: "%{icon} %{name}%{duration_part}"
+  execution_running: "%{spinner} [%{done_count}/%{total_count}]%{task_names_part}"
+```
+
+```ruby
+Taski.progress.theme = "my-theme.yml"   # validated here, at assignment
+```
+
+The loaded theme is a real subclass of the `extends` theme: anything not
+declared falls back to that theme's rendering, with your declared colors,
+icons, spinner frames, formats and truncation still applied — the same
+semantics as overriding methods in a Ruby subclass. A colors-only theme
+therefore restyles every line.
+
+The file is validated fully at load (`Taski::Progress::Theme::LoadError`
+lists the offending key): unknown keys, unknown placeholders, type errors,
+and stray `%` all fail at assignment, never mid-run. Write a literal `%`
+as `%%`. Note the trust boundary precisely: a data theme cannot execute
+code, but color values are raw escape strings, so a theme does control
+what your terminal is told to display.
+
+Available placeholders (the names match the Ruby helper vocabulary):
+
+| Placeholder | Meaning |
+|---|---|
+| `%{name}` / `%{full_name}` | task class name, short / fully qualified |
+| `%{state}` | task state (`running`, `completed`, ...) |
+| `%{duration}` / `%{duration_part}` | formatted duration / `" (1.2s)"` only when present |
+| `%{error_message}` / `%{error_part}` | error text / `": msg"` only when present |
+| `%{group_name}` | current group name |
+| `%{stdout}` / `%{stdout_part}` | last output line (truncated) / `" \| line"` only when present |
+| `%{root_task_name}` | root task short name |
+| `%{done_count}` `%{total_count}` `%{failed_count}` `%{completed_count}` `%{skipped_count}` `%{pending_count}` | tallies (through `formats.count`) |
+| `%{total_duration}` | execution duration, formatted |
+| `%{task_names}` / `%{task_names_part}` | active task list (limited) / leading-space variant |
+| `%{spinner}` / `%{icon}` | current spinner frame / state-colored icon |
+| `%{green}` `%{red}` `%{yellow}` `%{dim}` `%{reset}` | raw color codes |
+
+Other sections: `spinner:` (`frames:`, `interval:`), `render_interval:`,
+`formats:` (`count:`, `duration_ms:`, `duration_s:`), `truncation:`
+(`list_limit:`, `list_separator:`, `list_suffix:`, `text_max:`,
+`text_suffix:`), and `fragments:` to restyle the `*_part` wrappers (e.g.
+`duration_part: " %{dim}(%{duration})%{reset}"` — the only-when-present
+logic stays in the engine and is not overridable).
+
+Data themes are deliberately logic-free. If a theme needs real control flow,
+write a Ruby theme — that's the upgrade path, with the same vocabulary.
+
+See `examples/themes/catppuccin-mocha.yml` for a complete truecolor example.
+
 ### File Output Mode
 
 When output is redirected, interactive spinners are automatically disabled:

--- a/examples/themes/catppuccin-mocha.yml
+++ b/examples/themes/catppuccin-mocha.yml
@@ -1,0 +1,51 @@
+# Taski data theme — Catppuccin Mocha (truecolor)
+#
+# Use it with:
+#   Taski.progress.theme = "examples/themes/catppuccin-mocha.yml"
+#
+# A data theme is inert YAML: no code runs, so themes can be shared and used
+# without reading them. Placeholders are %{name}-style; the available names
+# match the Theme::Base helper vocabulary (see docs/GUIDE.md).
+name: catppuccin-mocha
+schema: 1
+extends: detail
+
+colors:
+  green:  "\e[38;2;166;227;161m"
+  red:    "\e[38;2;243;139;168m"
+  yellow: "\e[38;2;249;226;175m"
+  dim:    "\e[38;2;108;112;134m"
+  reset:  "\e[0m"
+
+icons:
+  success: "✔"
+  failure: "✖"
+  pending: "●"
+  skip:    "◌"
+
+spinner:
+  frames: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+  interval: 0.08
+
+render_interval: 0.1
+
+truncation:
+  list_limit: 3
+  list_suffix: "…"
+  text_max: 40
+  text_suffix: "…"
+
+fragments:
+  duration_part: " %{dim}(%{duration})%{reset}"
+  error_part: ": %{red}%{error_message}%{reset}"
+
+templates:
+  task_pending:  "%{dim}%{icon} %{name}%{reset}"
+  task_start:    "%{yellow}%{spinner}%{reset} %{name}"
+  task_success:  "%{icon} %{name}%{duration_part}"
+  task_fail:     "%{icon} %{name}%{error_part}"
+  task_skip:     "%{icon} %{dim}%{name}%{reset}"
+  execution_start:    "%{dim}taski%{reset} starting %{root_task_name}"
+  execution_running:  "%{spinner} [%{done_count}/%{total_count}]%{task_names_part}%{stdout_part}"
+  execution_complete: "%{icon} %{done_count}/%{total_count} tasks%{dim} (%{total_duration})%{reset}"
+  execution_fail:     "%{icon} %{failed_count}/%{total_count} tasks failed%{dim} (%{total_duration})%{reset}"

--- a/lib/taski/progress/config.rb
+++ b/lib/taski/progress/config.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "pathname"
+require_relative "theme/declarative"
+
 module Taski
   module Progress
     # Configuration for progress display.
@@ -8,6 +11,9 @@ module Taski
     # @example
     #   Taski.progress.layout = Taski::Progress::Layout::Tree
     #   Taski.progress.theme = Taski::Progress::Theme::Detail
+    #
+    # @example Data theme (YAML file, loaded and validated at assignment)
+    #   Taski.progress.theme = "themes/catppuccin-mocha.yml"
     class Config
       attr_reader :layout, :theme, :output
 
@@ -26,7 +32,15 @@ module Taski
         invalidate!
       end
 
-      def theme=(klass)
+      # Accepts a Theme::Base subclass, or a String/Pathname to a YAML data
+      # theme (loaded via Theme.load — raises Theme::LoadError here, at
+      # assignment time, never later during a run).
+      def theme=(klass_or_path)
+        klass = if klass_or_path.is_a?(String) || klass_or_path.is_a?(Pathname)
+          Theme.load(klass_or_path)
+        else
+          klass_or_path
+        end
         validate_theme!(klass) if klass
         @theme = klass
         invalidate!

--- a/lib/taski/progress/theme/declarative.rb
+++ b/lib/taski/progress/theme/declarative.rb
@@ -1,0 +1,462 @@
+# frozen_string_literal: true
+
+require "yaml"
+require_relative "../info"
+require_relative "base"
+require_relative "default"
+require_relative "plain"
+require_relative "detail"
+require_relative "compact"
+
+module Taski
+  module Progress
+    module Theme
+      # Raised when a data theme fails to load or validate. Distinct from the
+      # ArgumentError Config raises for invalid theme CLASSES: load errors are
+      # I/O + schema problems in a theme FILE (or hash).
+      class LoadError < StandardError; end
+
+      # Load a data theme from a YAML file. Returns an anonymous subclass of
+      # the theme named by `extends` (IS-A Theme::Base, zero-arg .new) with the
+      # validated, frozen definition baked in — so it satisfies Config's
+      # existing theme contract unchanged.
+      #
+      # All validation happens here, fail-fast: unknown keys, type errors,
+      # stray %, unknown placeholders all raise Theme::LoadError naming the
+      # offending key. A theme that loads cannot fail at render time.
+      #
+      # @param path [String, Pathname] Path to the YAML theme file
+      # @return [Class] Anonymous theme class
+      # @raise [Theme::LoadError]
+      def self.load(path)
+        hash = begin
+          YAML.safe_load_file(path)
+        rescue Psych::Exception => e
+          # Covers SyntaxError, AliasesNotEnabled (anchors/aliases/merge keys),
+          # DisallowedClass (unquoted dates/timestamps), BadAlias — all of
+          # which safe_load_file raises on ordinary malformed input.
+          raise LoadError, "#{path}: invalid YAML: #{e.message}"
+        rescue SystemCallError => e
+          raise LoadError, "#{path}: #{e.message}"
+        end
+        Declarative.from_hash(hash, source: path.to_s)
+      end
+
+      # Programmatic variant of {Theme.load} for an already-parsed Hash.
+      #
+      # @param hash [Hash] Theme definition (string or symbol keys)
+      # @return [Class] Anonymous theme class
+      # @raise [Theme::LoadError]
+      def self.from_hash(hash)
+        Declarative.from_hash(hash)
+      end
+
+      # Data themes: progress display customization from an inert YAML file —
+      # no code, safe to share and use without reading. Templates are
+      # %{placeholder} format strings; the placeholder names ARE the
+      # Theme::Base helper names (%{duration_part}, %{icon}, %{spinner}, ...),
+      # so the Ruby-theme vocabulary and the data-theme vocabulary are one.
+      #
+      # {Declarative.from_hash} builds an anonymous class that REALLY inherits
+      # from the `extends` theme with {Declarative::Behavior} layered on top.
+      # Declared templates render from their format strings; everything
+      # undeclared falls through to the extends theme's own methods — executed
+      # on the same instance, so declared colors, icons, spinner frames,
+      # formats, fragments and truncation knobs apply to fallback-rendered
+      # lines too, exactly like a Ruby subclass would behave.
+      #
+      # Logic-free by design: the only-when-present guards live in the engine
+      # (the same *_part methods Ruby themes use); only the wrapper strings,
+      # icons, colors, spinner frames, formats and truncation knobs are data.
+      # A theme that needs real control flow is a Ruby theme.
+      #
+      # @example
+      #   Taski.progress.theme = "my-theme.yml"
+      #   # or explicitly:
+      #   Taski.progress.theme = Taski::Progress::Theme.load("my-theme.yml")
+      module Declarative
+        TEMPLATE_KEYS = %i[task_pending task_start task_success task_fail task_skip
+          clean_start clean_success clean_fail group_start group_success group_fail
+          execution_start execution_running execution_complete execution_fail].freeze
+        EXECUTION_TEMPLATES = %i[execution_start execution_running execution_complete execution_fail].freeze
+        EXTENDS = {"base" => Base, "default" => Default, "plain" => Plain,
+                   "detail" => Detail, "compact" => Compact}.freeze
+
+        # Validated, immutable result of loading a data theme.
+        Definition = ::Data.define(:name, :templates, :icons, :colors, :spinner_frames,
+          :spinner_interval, :render_interval, :formats, :truncation, :fragments, :extends_class)
+
+        # Build an anonymous theme class with the validated definition baked
+        # in at class level. The class inherits from the extends theme, so
+        # `klass <= Theme::Base` holds and Config's zero-arg `.new` works.
+        #
+        # @raise [Theme::LoadError]
+        def self.from_hash(hash, source: "(hash)")
+          defn = Loader.new(hash, source: source).definition
+          klass = Class.new(defn.extends_class) do
+            include Behavior
+
+            @definition = defn
+            class << self
+              attr_reader :definition
+            end
+          end
+          Loader.validation_render!(klass, source)
+          klass
+        end
+
+        # The data-theme layer: declared values win, everything else falls
+        # through (`super`) to the extends theme — on the same instance.
+        module Behavior
+          def initialize
+            @definition = self.class.definition or
+              raise LoadError, "data themes must be built via Theme.load / Theme.from_hash"
+            super
+          end
+
+          # 15 generated template methods: declared format string if present,
+          # else the extends theme's own rendering (which sees the declared
+          # colors/icons/etc. through the overrides below).
+          TEMPLATE_KEYS.each do |key|
+            define_method(key) do |task: nil, execution: nil|
+              tpl = @definition.templates[key]
+              next super(task: task, execution: execution) unless tpl
+              format(tpl, **placeholders(key, task, execution))
+            end
+          end
+
+          # === Config values: declared wins, else the extends theme ===
+          # fetch-with-block keeps explicitly-declared "" values (Plain-style).
+
+          def spinner_frames = @definition.spinner_frames || super
+
+          def spinner_interval = @definition.spinner_interval || super
+
+          def render_interval = @definition.render_interval || super
+
+          def icon_success = @definition.icons.fetch(:success) { super }
+
+          def icon_failure = @definition.icons.fetch(:failure) { super }
+
+          def icon_pending = @definition.icons.fetch(:pending) { super }
+
+          def icon_skip = @definition.icons.fetch(:skip) { super }
+
+          def color_green = @definition.colors.fetch(:green) { super }
+
+          def color_red = @definition.colors.fetch(:red) { super }
+
+          def color_yellow = @definition.colors.fetch(:yellow) { super }
+
+          def color_dim = @definition.colors.fetch(:dim) { super }
+
+          def color_reset = @definition.colors.fetch(:reset) { super }
+
+          def truncate_list_limit = @definition.truncation.fetch(:list_limit) { super }
+
+          def truncate_list_separator = @definition.truncation.fetch(:list_separator) { super }
+
+          def truncate_list_suffix = @definition.truncation.fetch(:list_suffix) { super }
+
+          def truncate_text_max = @definition.truncation.fetch(:text_max) { super }
+
+          def truncate_text_suffix = @definition.truncation.fetch(:text_suffix) { super }
+
+          def format_count(count)
+            tpl = @definition.formats[:count]
+            return super unless tpl
+            format(tpl, count: count)
+          end
+
+          # The >=1000ms branch stays engine logic; only the leaf strings are data.
+          def format_duration(ms)
+            return "" if ms.nil?
+            s_tpl, ms_tpl = @definition.formats.values_at(:duration_s, :duration_ms)
+            return super unless s_tpl || ms_tpl
+            if ms >= 1000
+              format(s_tpl || "%{s}s", s: (ms / 1000.0).round(1))
+            else
+              format(ms_tpl || "%{ms}ms", ms: ms)
+            end
+          end
+
+          # === Fragment wrappers: the string is data, the presence guard is
+          # engine-fixed. Undeclared fragments use the extends implementation,
+          # which routes through the declared formats/knobs via self. ===
+
+          def duration_part(duration)
+            tpl = @definition.fragments[:duration_part]
+            return super unless tpl
+            return "" if duration.nil?
+            format(tpl, duration: format_duration(duration), **color_placeholders)
+          end
+
+          def error_part(error_message)
+            tpl = @definition.fragments[:error_part]
+            return super unless tpl
+            return "" if error_message.nil? || error_message.to_s.empty?
+            format(tpl, error_message: error_message, **color_placeholders)
+          end
+
+          def stdout_part(stdout)
+            tpl = @definition.fragments[:stdout_part]
+            return super unless tpl
+            return "" if stdout.nil? || stdout.to_s.empty?
+            format(tpl, stdout: truncate_text(stdout, truncate_text_max), **color_placeholders)
+          end
+
+          def task_names_part(task_names)
+            tpl = @definition.fragments[:task_names_part]
+            return super unless tpl
+            return "" if task_names.nil? || task_names.empty?
+            format(tpl, task_names: joined_task_names(task_names), **color_placeholders)
+          end
+
+          private
+
+          def color_placeholders
+            {green: color_green, red: color_red, yellow: color_yellow, dim: color_dim, reset: color_reset}
+          end
+
+          def joined_task_names(names) = truncate_list(names.map { |n| short_name(n) }, truncate_list_limit)
+
+          # The uniform payload: every template is formatted against the full
+          # key set (absent data renders ""/"0"); Kernel#format ignores extra
+          # keys, so one sample payload validates everything at load time.
+          # Runs inside render_theme's rescue at render time — any surprise
+          # isolates.
+          def placeholders(key, task, execution)
+            icon_state = EXECUTION_TEMPLATES.include?(key) ? execution&.state : task&.state
+            {
+              name: short_name(task&.name),
+              full_name: task&.name.to_s,
+              state: task&.state.to_s,
+              duration: task&.duration ? format_duration(task.duration) : "",
+              duration_part: duration_part(task&.duration),
+              error_message: task&.error_message.to_s,
+              error_part: error_part(task&.error_message),
+              group_name: task&.group_name.to_s,
+              stdout: task&.stdout ? truncate_text(task.stdout, truncate_text_max) : "",
+              stdout_part: stdout_part(task&.stdout),
+              root_task_name: short_name(execution&.root_task_name),
+              done_count: format_count(execution&.done_count || 0),
+              total_count: format_count(execution&.total_count || 0),
+              failed_count: format_count(execution&.failed_count || 0),
+              completed_count: format_count(execution&.completed_count || 0),
+              skipped_count: format_count(execution&.skipped_count || 0),
+              pending_count: format_count(execution&.pending_count || 0),
+              total_duration: format_duration(execution&.total_duration || 0),
+              task_names: (execution&.task_names && !execution.task_names.empty?) ? joined_task_names(execution.task_names) : "",
+              task_names_part: task_names_part(execution&.task_names),
+              spinner: spinner_frame(execution&.spinner_index),
+              icon: icon_for(icon_state),
+              **color_placeholders
+            }
+          end
+        end
+
+        # Validates a raw theme hash into a frozen Definition. Closed key sets
+        # everywhere: anything unknown fails at load with the allowed keys in
+        # the message, never silently at render.
+        class Loader
+          TOP_KEYS = %w[name schema extends templates icons colors spinner render_interval formats truncation fragments].freeze
+          ICON_KEYS = %w[success failure pending skip].freeze
+          COLOR_KEYS = %w[green red yellow dim reset].freeze
+          SPINNER_KEYS = %w[frames interval].freeze
+          FORMAT_KEYS = %w[count duration_ms duration_s].freeze
+          TRUNCATION_KEYS = %w[list_limit list_separator list_suffix text_max text_suffix].freeze
+          FRAGMENT_KEYS = %w[duration_part error_part stdout_part task_names_part].freeze
+          INTEGER_TRUNCATION_KEYS = %w[list_limit text_max].freeze
+
+          # Render/spinner intervals are seconds on background-thread sleeps:
+          # non-finite or huge values would kill or wedge those threads, tiny
+          # values busy-loop the CPU. Bounded here so a loaded theme can't.
+          INTERVAL_RANGE = (0.01..60)
+
+          # Fully-populated sample inputs for the validation render: with the
+          # uniform payload, one render per declared template is exhaustive.
+          SAMPLE_TASK = TaskInfo.new(name: "Sample::SampleTask", state: :completed,
+            duration: 1234, error_message: "sample error", group_name: "sample",
+            stdout: "sample output line")
+          SAMPLE_EXECUTION = ExecutionInfo.new(state: :completed, pending_count: 1,
+            done_count: 2, completed_count: 2, failed_count: 1, skipped_count: 1,
+            total_count: 5, total_duration: 1234, root_task_name: "Sample::Root",
+            task_names: ["Sample::SampleTask"], spinner_index: 0)
+
+          def initialize(hash, source:)
+            @source = source
+            raise err("top level must be a mapping (got #{hash.class})") unless hash.is_a?(Hash)
+            @hash = stringify_keys(hash)
+            # Schema first: a future-schema file should fail with "unsupported
+            # schema version", not with whatever unknown key it contains.
+            schema_version!
+            check_keys(@hash, TOP_KEYS, "top level")
+          end
+
+          def definition
+            Definition.new(
+              name: string_value("name"),
+              templates: validated_templates,
+              icons: section_of_strings("icons", ICON_KEYS),
+              colors: section_of_strings("colors", COLOR_KEYS),
+              spinner_frames: spinner_value("frames"),
+              spinner_interval: spinner_value("interval"),
+              render_interval: bounded_interval("render_interval", @hash["render_interval"]),
+              formats: validated_format_strings("formats", FORMAT_KEYS),
+              truncation: validated_truncation,
+              fragments: validated_format_strings("fragments", FRAGMENT_KEYS),
+              extends_class: extends_class
+            ).freeze
+          end
+
+          # Render every declared template and fragment once against the fully
+          # populated sample payload — catches unknown placeholders (KeyError)
+          # and malformed format strings the percent check cannot see.
+          def self.validation_render!(klass, source)
+            theme = klass.new
+            defn = klass.definition
+            defn.templates.each_key do |key|
+              theme.public_send(key, task: SAMPLE_TASK, execution: SAMPLE_EXECUTION)
+            rescue KeyError => e
+              raise LoadError, "#{source}: unknown placeholder in templates.#{key}: #{e.message}"
+            rescue => e
+              raise LoadError, "#{source}: malformed format string in templates.#{key}: #{e.message}"
+            end
+            {duration_part: -> { theme.duration_part(1234) },
+             error_part: -> { theme.error_part("sample error") },
+             stdout_part: -> { theme.stdout_part("sample output line") },
+             task_names_part: -> { theme.task_names_part(["Sample::SampleTask"]) }}.each do |key, render|
+              next unless defn.fragments.key?(key)
+              begin
+                render.call
+              rescue KeyError => e
+                raise LoadError, "#{source}: unknown placeholder in fragments.#{key}: #{e.message}"
+              rescue => e
+                raise LoadError, "#{source}: malformed format string in fragments.#{key}: #{e.message}"
+              end
+            end
+            [123, 1500].each { |ms| theme.format_duration(ms) }
+            theme.format_count(1)
+          rescue KeyError => e
+            raise LoadError, "#{source}: unknown placeholder in formats: #{e.message}"
+          end
+
+          private
+
+          def err(message) = LoadError.new("#{@source}: #{message}")
+
+          # Accept symbol keys everywhere a YAML file would have strings, so
+          # from_hash works naturally from Ruby. One level of nesting is all
+          # the schema has.
+          def stringify_keys(hash)
+            hash.to_h do |key, value|
+              [key.to_s, value.is_a?(Hash) ? value.transform_keys(&:to_s) : value]
+            end
+          end
+
+          def check_keys(hash, allowed, where)
+            unknown = hash.keys - allowed
+            return if unknown.empty?
+            raise err("unknown key #{unknown.first.inspect} in #{where} (allowed: #{allowed.join(", ")})")
+          end
+
+          def schema_version!
+            version = @hash.fetch("schema", 1)
+            raise err("schema must be an Integer (got #{version.inspect})") unless version.is_a?(Integer)
+            raise err("unsupported schema version #{version} (this taski supports 1)") unless version == 1
+          end
+
+          def section(name, allowed)
+            value = @hash[name]
+            return {} if value.nil?
+            raise err("#{name} must be a mapping (got #{value.class})") unless value.is_a?(Hash)
+            check_keys(value, allowed, name)
+            value
+          end
+
+          def string_value(key)
+            value = @hash[key]
+            return nil if value.nil?
+            raise err("#{key} must be a String (got #{value.class})") unless value.is_a?(String)
+            value.dup.freeze
+          end
+
+          def extends_class
+            value = @hash.fetch("extends", "default")
+            EXTENDS.fetch(value) do
+              raise err("unknown extends #{value.inspect} (allowed: #{EXTENDS.keys.join(", ")})")
+            end
+          end
+
+          def validated_templates
+            section("templates", TEMPLATE_KEYS.map(&:to_s)).each_with_object({}) do |(key, value), out|
+              out[key.to_sym] = format_string!("templates.#{key}", value)
+            end.freeze
+          end
+
+          def section_of_strings(name, allowed)
+            section(name, allowed).each_with_object({}) do |(key, value), out|
+              raise err("#{name}.#{key} must be a String (got #{value.class})") unless value.is_a?(String)
+              out[key.to_sym] = value.dup.freeze
+            end.freeze
+          end
+
+          def validated_format_strings(name, allowed)
+            section(name, allowed).each_with_object({}) do |(key, value), out|
+              out[key.to_sym] = format_string!("#{name}.#{key}", value)
+            end.freeze
+          end
+
+          def spinner_value(key)
+            spinner = section("spinner", SPINNER_KEYS)
+            value = spinner[key]
+            return nil if value.nil?
+            case key
+            when "frames"
+              unless value.is_a?(Array) && value.all?(String)
+                raise err("spinner.frames must be an Array of String")
+              end
+              value.map { |frame| frame.dup.freeze }.freeze
+            when "interval"
+              bounded_interval("spinner.interval", value)
+            end
+          end
+
+          def bounded_interval(label, value)
+            return nil if value.nil?
+            unless value.is_a?(Numeric) && value.finite? && INTERVAL_RANGE.cover?(value)
+              raise err("#{label} must be a number of seconds between #{INTERVAL_RANGE.min} and #{INTERVAL_RANGE.max} (got #{value.inspect})")
+            end
+            value
+          end
+
+          def validated_truncation
+            section("truncation", TRUNCATION_KEYS).each_with_object({}) do |(key, value), out|
+              if INTEGER_TRUNCATION_KEYS.include?(key)
+                unless value.is_a?(Integer) && value.positive?
+                  raise err("truncation.#{key} must be a positive Integer (got #{value.inspect})")
+                end
+                out[key.to_sym] = value
+              else
+                raise err("truncation.#{key} must be a String (got #{value.class})") unless value.is_a?(String)
+                out[key.to_sym] = value.dup.freeze
+              end
+            end.freeze
+          end
+
+          # The vocabulary is %{...} plus %% only. Stripping those must leave
+          # no % behind — this rejects %s/%d (which Kernel#format would
+          # silently interpolate from the payload hash), lone %, unclosed %{,
+          # and the %<name>s form.
+          def format_string!(label, value)
+            raise err("#{label} must be a String (got #{value.class})") unless value.is_a?(String)
+            if value.gsub(/%%|%\{[^}]*\}/, "").include?("%")
+              raise err("#{label} contains a stray % — the placeholder syntax is %{name}; escape a literal % as %%")
+            end
+            value.dup.freeze
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/themes/compact.yml
+++ b/test/fixtures/themes/compact.yml
@@ -1,0 +1,10 @@
+# YAML re-encoding of Taski::Progress::Theme::Compact — byte-parity fixture.
+# The old Liquid {% for %}/forloop loop collapses into %{task_names_part}.
+name: compact-parity
+schema: 1
+extends: default
+
+templates:
+  execution_running:  "%{spinner} [%{done_count}/%{total_count}]%{task_names_part}%{stdout_part}"
+  execution_complete: "%{icon} [TASKI] Completed: %{done_count}/%{total_count} tasks (%{total_duration})"
+  execution_fail:     "%{icon} [TASKI] Failed: %{failed_count}/%{total_count} tasks (%{total_duration})"

--- a/test/fixtures/themes/default.yml
+++ b/test/fixtures/themes/default.yml
@@ -1,0 +1,24 @@
+# YAML re-encoding of Taski::Progress::Theme::Default — byte-parity fixture.
+# All 15 templates spelled out so every format string goes through the
+# data-theme pipeline (extends base would behave identically; the point is
+# exercising the placeholders).
+name: default-parity
+schema: 1
+extends: base
+
+templates:
+  task_pending:  "[PENDING] %{name}"
+  task_start:    "[START] %{name}"
+  task_success:  "[DONE] %{name}%{duration_part}"
+  task_fail:     "[FAIL] %{name}%{error_part}"
+  task_skip:     "[SKIP] %{name}"
+  clean_start:   "[CLEAN] %{name}"
+  clean_success: "[CLEAN DONE] %{name}%{duration_part}"
+  clean_fail:    "[CLEAN FAIL] %{name}%{error_part}"
+  group_start:   "[GROUP] %{name}#%{group_name}"
+  group_success: "[GROUP DONE] %{name}#%{group_name}%{duration_part}"
+  group_fail:    "[GROUP FAIL] %{name}#%{group_name}%{error_part}"
+  execution_start:    "[TASKI] Starting %{root_task_name}"
+  execution_running:  "[TASKI] Running: %{done_count}/%{total_count} tasks"
+  execution_complete: "[TASKI] Completed: %{done_count}/%{total_count} tasks (%{total_duration})"
+  execution_fail:     "[TASKI] Failed: %{failed_count}/%{total_count} tasks (%{total_duration})"

--- a/test/fixtures/themes/detail.yml
+++ b/test/fixtures/themes/detail.yml
@@ -1,0 +1,13 @@
+# YAML re-encoding of Taski::Progress::Theme::Detail — byte-parity fixture.
+# Only the 5 task-template deltas are declared; everything else falls back to
+# the extends theme.
+name: detail-parity
+schema: 1
+extends: default
+
+templates:
+  task_pending: "%{icon} %{name}"
+  task_start:   "%{spinner} %{name}"
+  task_success: "%{icon} %{name}%{duration_part}"
+  task_fail:    "%{icon} %{name}%{error_part}"
+  task_skip:    "%{icon} %{name}"

--- a/test/fixtures/themes/plain.yml
+++ b/test/fixtures/themes/plain.yml
@@ -1,0 +1,13 @@
+# YAML re-encoding of Taski::Progress::Theme::Plain — byte-parity fixture.
+# Plain = Default with all color codes empty; explicitly-declared "" must
+# survive (not fall back to the extends theme's ANSI codes).
+name: plain-parity
+schema: 1
+extends: default
+
+colors:
+  green:  ""
+  red:    ""
+  yellow: ""
+  dim:    ""
+  reset:  ""

--- a/test/test_theme_declarative.rb
+++ b/test/test_theme_declarative.rb
@@ -1,0 +1,532 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "json"
+require "stringio"
+require "tempfile"
+require "pathname"
+
+# Data themes (Theme::Declarative): inert YAML loaded via Theme.load /
+# Theme.from_hash into an anonymous Theme::Base subclass. Fail-fast contract:
+# everything that can be wrong with a theme file raises Theme::LoadError at
+# load time with the offending key in the message — a theme that loads cannot
+# fail at render time.
+class TestThemeDeclarative < Minitest::Test
+  THEME = Taski::Progress::Theme
+  FIXTURES = File.expand_path("fixtures/themes", __dir__)
+
+  def task_info(**fields) = Taski::Progress::TaskInfo.new(**fields)
+
+  def execution_info(**fields) = Taski::Progress::ExecutionInfo.new(**fields)
+
+  # === Happy path ===
+
+  def test_from_hash_returns_theme_base_subclass_with_zero_arg_new
+    klass = THEME.from_hash({"templates" => {"task_start" => "GO %{name}"}})
+    assert_operator klass, :<=, THEME::Base
+    theme = klass.new
+    assert_equal "GO MyTask", theme.task_start(task: task_info(name: "A::MyTask"))
+  end
+
+  def test_load_reads_yaml_file
+    with_theme_file(<<~YAML) do |path|
+      templates:
+        task_start: "GO %{name}"
+    YAML
+      theme = THEME.load(path).new
+      assert_equal "GO MyTask", theme.task_start(task: task_info(name: "A::MyTask"))
+    end
+  end
+
+  def test_undeclared_templates_fall_back_to_extends_theme
+    klass = THEME.from_hash({
+      "extends" => "compact",
+      "templates" => {"task_start" => "GO %{name}"}
+    })
+    theme = klass.new
+    # execution_running comes from Compact (spinner + [done/total])
+    out = theme.execution_running(execution: execution_info(done_count: 3, total_count: 5, spinner_index: 0))
+    assert_equal "⠋ [3/5]", out
+  end
+
+  def test_default_extends_is_default_theme
+    klass = THEME.from_hash({})
+    assert_operator klass, :<=, THEME::Default,
+      "with no extends, the loaded theme must inherit from Default"
+    assert_equal "[START] MyTask", klass.new.task_start(task: task_info(name: "MyTask"))
+  end
+
+  def test_from_hash_accepts_symbol_keys
+    klass = THEME.from_hash({
+      schema: 1,
+      extends: "detail",
+      icons: {success: "🎉"},
+      templates: {task_start: "GO %{name}"}
+    })
+    theme = klass.new
+    assert_equal "GO T", theme.task_start(task: task_info(name: "T"))
+    assert_equal "🎉", theme.icon_success
+  end
+
+  def test_from_hash_symbol_keys_do_not_bypass_validation
+    assert_raises(THEME::LoadError) { THEME.from_hash({schema: 99}) }
+    assert_raises(THEME::LoadError) { THEME.from_hash({templats: {}}) }
+    assert_raises(THEME::LoadError) { THEME.from_hash({templates: {task_strat: "x"}}) }
+  end
+
+  # === Declared config applies to FALLBACK-rendered templates too ===
+  # The loaded class really inherits from the extends theme, so a colors-only
+  # or icons-only theme styles every line — same semantics as a Ruby subclass.
+
+  def test_declared_colors_apply_to_fallback_rendered_templates
+    klass = THEME.from_hash({
+      "extends" => "detail",
+      "colors" => {"green" => "<G>", "reset" => "<R>"}
+    })
+    theme = klass.new
+    # task_success is NOT declared — Detail renders it, with the YAML colors
+    out = theme.task_success(task: task_info(name: "T", state: :completed, duration: 123))
+    assert_equal "<G>✓<R> T (123ms)", out
+  end
+
+  def test_declared_icons_apply_to_fallback_rendered_templates
+    klass = THEME.from_hash({
+      "extends" => "detail",
+      "icons" => {"success" => "🎉"},
+      "colors" => {"green" => "", "reset" => ""}
+    })
+    out = klass.new.task_success(task: task_info(name: "T", state: :completed))
+    assert_equal "🎉 T", out
+  end
+
+  def test_declared_spinner_frames_apply_to_fallback_rendered_templates
+    # No spinner split-brain: the fallback-rendered Detail#task_start must use
+    # the YAML frames, consistently with the layout timer's modulo.
+    klass = THEME.from_hash({
+      "extends" => "detail",
+      "spinner" => {"frames" => ["A", "B"]}
+    })
+    theme = klass.new
+    out = theme.task_start(task: task_info(name: "T"), execution: execution_info(spinner_index: 1))
+    assert_equal "B T", out
+  end
+
+  def test_declared_fragments_apply_to_fallback_rendered_templates
+    klass = THEME.from_hash({"fragments" => {"duration_part" => " [%{duration}]"}})
+    # task_success is undeclared — Default renders it through our fragment
+    out = klass.new.task_success(task: task_info(name: "T", duration: 123))
+    assert_equal "[DONE] T [123ms]", out
+  end
+
+  # === Placeholder vocabulary ===
+
+  def test_color_placeholders_resolve_theme_colors
+    klass = THEME.from_hash({
+      "colors" => {"green" => "<G>", "reset" => "<R>"},
+      "templates" => {"task_success" => "%{green}%{name}%{reset}"}
+    })
+    assert_equal "<G>T<R>", klass.new.task_success(task: task_info(name: "T"))
+  end
+
+  def test_icon_placeholder_uses_task_state_for_task_templates
+    klass = THEME.from_hash({"templates" => {"task_success" => "%{icon} %{name}"}})
+    out = klass.new.task_success(task: task_info(name: "T", state: :completed))
+    assert_equal "\e[32m✓\e[0m T", out
+  end
+
+  def test_icon_placeholder_uses_execution_state_for_execution_templates
+    klass = THEME.from_hash({"templates" => {"execution_fail" => "%{icon} ng"}})
+    out = klass.new.execution_fail(execution: execution_info(state: :failed))
+    assert_equal "\e[31m✗\e[0m ng", out
+  end
+
+  def test_spinner_placeholder_resolves_spinner_index
+    klass = THEME.from_hash({"templates" => {"execution_running" => "%{spinner}"}})
+    theme = klass.new
+    assert_equal "⠸", theme.execution_running(execution: execution_info(spinner_index: 3))
+  end
+
+  def test_literal_percent_escaped_as_double_percent
+    klass = THEME.from_hash({"templates" => {"task_start" => "%{name} 100%% done"}})
+    assert_equal "T 100% done", klass.new.task_start(task: task_info(name: "T"))
+  end
+
+  def test_counts_route_through_format_count
+    klass = THEME.from_hash({
+      "formats" => {"count" => "%{count}件"},
+      "templates" => {"execution_running" => "%{done_count}/%{total_count}"}
+    })
+    out = klass.new.execution_running(execution: execution_info(done_count: 3, total_count: 5))
+    assert_equal "3件/5件", out
+  end
+
+  def test_duration_format_strings_cover_both_branches
+    klass = THEME.from_hash({"formats" => {"duration_ms" => "%{ms}ミリ秒", "duration_s" => "%{s}秒"}})
+    theme = klass.new
+    assert_equal "123ミリ秒", theme.format_duration(123)
+    assert_equal "1.2秒", theme.format_duration(1234)
+    assert_equal "", theme.format_duration(nil)
+  end
+
+  def test_format_duration_switches_to_seconds_at_exactly_1000ms
+    klass = THEME.from_hash({"formats" => {"duration_ms" => "%{ms}ms!", "duration_s" => "%{s}s!"}})
+    theme = klass.new
+    assert_equal "999ms!", theme.format_duration(999)
+    assert_equal "1.0s!", theme.format_duration(1000)
+  end
+
+  # === Config values: declared wins, "" survives, else fallback ===
+
+  def test_declared_empty_color_survives_and_does_not_fall_back
+    klass = THEME.from_hash({"colors" => {"green" => ""}})
+    theme = klass.new
+    assert_equal "", theme.color_green
+    # undeclared color falls back to the extends theme (Default ANSI)
+    assert_equal "\e[31m", theme.color_red
+  end
+
+  def test_icons_spinner_and_intervals_come_from_definition
+    klass = THEME.from_hash({
+      "icons" => {"success" => "🎉"},
+      "spinner" => {"frames" => ["A", "B"], "interval" => 0.5},
+      "render_interval" => 0.25
+    })
+    theme = klass.new
+    assert_equal "🎉", theme.icon_success
+    assert_equal "✗", theme.icon_failure
+    assert_equal ["A", "B"], theme.spinner_frames
+    assert_in_delta 0.5, theme.spinner_interval
+    assert_in_delta 0.25, theme.render_interval
+    assert_equal "B", theme.spinner_frame(1)
+  end
+
+  def test_truncation_knobs_honored_by_parts
+    klass = THEME.from_hash({
+      "truncation" => {"list_limit" => 2, "list_suffix" => "…", "text_max" => 10, "text_suffix" => "…"}
+    })
+    theme = klass.new
+    assert_equal " T1, T2…", theme.task_names_part(%w[A::T1 B::T2 C::T3])
+    assert_equal " | 123456789…", theme.stdout_part("123456789012345")
+  end
+
+  # === Fragments: wrapper string is data, presence guard is engine-fixed ===
+
+  def test_fragment_wrappers_are_data_with_color_placeholders
+    klass = THEME.from_hash({
+      "fragments" => {"duration_part" => " %{dim}(%{duration})%{reset}"},
+      "colors" => {"dim" => "<D>", "reset" => "<R>"}
+    })
+    theme = klass.new
+    assert_equal " <D>(123ms)<R>", theme.duration_part(123)
+    assert_equal "", theme.duration_part(nil), "nil guard is engine-fixed, not overridable"
+  end
+
+  def test_fragment_presence_guards_are_engine_fixed
+    klass = THEME.from_hash({"fragments" => {"error_part" => "!!%{error_message}!!"}})
+    theme = klass.new
+    assert_equal "!!boom!!", theme.error_part("boom")
+    assert_equal "", theme.error_part(nil)
+    assert_equal "", theme.error_part("")
+  end
+
+  # === Fail-fast load validation ===
+
+  def test_unknown_top_level_key_raises
+    error = assert_raises(THEME::LoadError) { THEME.from_hash({"templats" => {}}) }
+    assert_includes error.message, "templats"
+    assert_includes error.message, "allowed:"
+  end
+
+  def test_unknown_template_key_raises
+    error = assert_raises(THEME::LoadError) { THEME.from_hash({"templates" => {"task_strat" => "x"}}) }
+    assert_includes error.message, "task_strat"
+  end
+
+  def test_unknown_section_keys_raise
+    assert_raises(THEME::LoadError) { THEME.from_hash({"icons" => {"sucess" => "x"}}) }
+    assert_raises(THEME::LoadError) { THEME.from_hash({"colors" => {"blue" => "x"}}) }
+    assert_raises(THEME::LoadError) { THEME.from_hash({"fragments" => {"durtion_part" => "x"}}) }
+    assert_raises(THEME::LoadError) { THEME.from_hash({"truncation" => {"limit" => 3}}) }
+  end
+
+  def test_unknown_placeholder_raises_naming_the_template
+    error = assert_raises(THEME::LoadError) do
+      THEME.from_hash({"templates" => {"task_success" => "%{nope}"}})
+    end
+    assert_includes error.message, "templates.task_success"
+  end
+
+  def test_unknown_placeholder_in_fragment_raises_naming_the_fragment
+    error = assert_raises(THEME::LoadError) do
+      THEME.from_hash({"fragments" => {"error_part" => ": %{nope}"}})
+    end
+    assert_includes error.message, "fragments.error_part"
+  end
+
+  def test_stray_percent_forms_rejected
+    ["100%", "%s", "%d", "%{name", "%<name>s"].each do |bad|
+      error = assert_raises(THEME::LoadError, "expected #{bad.inspect} to be rejected") do
+        THEME.from_hash({"templates" => {"task_start" => bad}})
+      end
+      assert_includes error.message, "stray %"
+    end
+  end
+
+  def test_unsupported_schema_version_raises
+    error = assert_raises(THEME::LoadError) { THEME.from_hash({"schema" => 2}) }
+    assert_includes error.message, "schema version 2"
+    assert_raises(THEME::LoadError) { THEME.from_hash({"schema" => "1"}) }
+    assert_raises(THEME::LoadError) { THEME.from_hash({"schema" => 0}) }
+    assert_raises(THEME::LoadError) { THEME.from_hash({"schema" => -1}) }
+  end
+
+  def test_schema_is_checked_before_unknown_keys
+    # A future-schema file must fail with the forward-compat message, not
+    # with whatever unknown key it happens to contain.
+    error = assert_raises(THEME::LoadError) do
+      THEME.from_hash({"schema" => 2, "future_section" => {}})
+    end
+    assert_includes error.message, "schema version 2"
+  end
+
+  def test_unknown_extends_raises
+    error = assert_raises(THEME::LoadError) { THEME.from_hash({"extends" => "fancy"}) }
+    assert_includes error.message, "fancy"
+  end
+
+  def test_type_errors_raise
+    assert_raises(THEME::LoadError) { THEME.from_hash({"templates" => {"task_start" => 1}}) }
+    assert_raises(THEME::LoadError) { THEME.from_hash({"spinner" => {"frames" => "abc"}}) }
+    assert_raises(THEME::LoadError) { THEME.from_hash({"spinner" => {"interval" => -1}}) }
+    assert_raises(THEME::LoadError) { THEME.from_hash({"render_interval" => 0}) }
+    assert_raises(THEME::LoadError) { THEME.from_hash({"truncation" => {"list_limit" => "three"}}) }
+    assert_raises(THEME::LoadError) { THEME.from_hash({"name" => 42}) }
+  end
+
+  def test_intervals_must_be_finite_and_bounded
+    # .inf parses to Float::INFINITY — accepting it would kill the spinner /
+    # render threads with RangeError from sleep and abort on_stop teardown
+    # (hidden cursor, lost queued messages). Tiny values busy-loop the CPU.
+    [Float::INFINITY, 1.0e20, 0.0001, 61].each do |bad|
+      error = assert_raises(THEME::LoadError, "expected interval #{bad} rejected") do
+        THEME.from_hash({"spinner" => {"interval" => bad}})
+      end
+      assert_includes error.message, "spinner.interval"
+      assert_raises(THEME::LoadError) { THEME.from_hash({"render_interval" => bad}) }
+    end
+    # sane values still load
+    theme = THEME.from_hash({"spinner" => {"interval" => 0.05}, "render_interval" => 1}).new
+    assert_in_delta 0.05, theme.spinner_interval
+    assert_in_delta 1, theme.render_interval
+  end
+
+  def test_truncation_integers_must_be_positive
+    [0, -1].each do |bad|
+      error = assert_raises(THEME::LoadError) { THEME.from_hash({"truncation" => {"list_limit" => bad}}) }
+      assert_includes error.message, "truncation.list_limit"
+      error = assert_raises(THEME::LoadError) { THEME.from_hash({"truncation" => {"text_max" => bad}}) }
+      assert_includes error.message, "truncation.text_max"
+    end
+  end
+
+  def test_non_mapping_top_level_raises
+    assert_raises(THEME::LoadError) { THEME.from_hash(nil) }
+    assert_raises(THEME::LoadError) { THEME.from_hash([1, 2]) }
+  end
+
+  def test_missing_file_raises_load_error
+    error = assert_raises(THEME::LoadError) { THEME.load("/no/such/theme.yml") }
+    assert_includes error.message, "/no/such/theme.yml"
+  end
+
+  def test_invalid_yaml_raises_load_error
+    with_theme_file("templates: [unclosed") do |path|
+      error = assert_raises(THEME::LoadError) { THEME.load(path) }
+      assert_includes error.message, "invalid YAML"
+    end
+  end
+
+  def test_yaml_aliases_raise_load_error_naming_the_file
+    # safe_load_file raises Psych::AliasesNotEnabled for anchors/aliases —
+    # it must surface as LoadError (the documented contract), not raw Psych.
+    with_theme_file(<<~YAML) do |path|
+      colors:
+        green: &g "\\e[32m"
+        dim: *g
+    YAML
+      error = assert_raises(THEME::LoadError) { THEME.load(path) }
+      assert_includes error.message, File.basename(path)
+    end
+  end
+
+  def test_yaml_date_scalars_raise_load_error
+    # Unquoted dates resolve to Date, which safe_load_file disallows
+    # (Psych::DisallowedClass) — must be wrapped as LoadError too.
+    with_theme_file("name: 2026-06-11\n") do |path|
+      assert_raises(THEME::LoadError) { THEME.load(path) }
+    end
+  end
+
+  def test_empty_file_raises_load_error
+    with_theme_file("") do |path|
+      assert_raises(THEME::LoadError) { THEME.load(path) }
+    end
+  end
+
+  def test_declarative_module_cannot_be_used_as_a_theme
+    # Declarative is the factory namespace, not a theme class — assigning it
+    # fails at assignment time (it is not a Class <= Theme::Base).
+    config = Taski::Progress::Config.new
+    assert_raises(ArgumentError) { config.theme = THEME::Declarative }
+  end
+
+  # === Byte-parity: YAML re-encodings of the 4 shipped themes reproduce the
+  # === Liquid-era baseline exactly, through the data-theme pipeline ===
+
+  def test_yaml_encoded_shipped_themes_match_liquid_baseline
+    baseline = JSON.parse(File.read(File.expand_path("fixtures/theme_parity_baseline.json", __dir__)))
+    themes = %w[default detail compact plain].to_h do |name|
+      [name, THEME.load(File.join(FIXTURES, "#{name}.yml")).new]
+    end
+
+    baseline.fetch("cases").each do |c|
+      theme = themes.fetch(c["theme"])
+      t = c["task"]
+      task = t && task_info(
+        name: t["name"], state: t["state"]&.to_sym, duration: t["duration"],
+        error_message: t["error_message"], group_name: t["group_name"], stdout: t["stdout"]
+      )
+      e = c.fetch("execution")
+      execution = execution_info(
+        state: e["state"]&.to_sym, pending_count: e["pending_count"],
+        done_count: e["done_count"], completed_count: e["completed_count"],
+        failed_count: e["failed_count"], skipped_count: e["skipped_count"],
+        total_count: e["total_count"], total_duration: e["total_duration"],
+        root_task_name: e["root_task_name"], task_names: e["task_names"],
+        spinner_index: c["spinner_index"]
+      )
+      actual = theme.public_send(c["method"], task: task, execution: execution)
+      assert_equal c["expected"], actual, "case #{c["id"]}: YAML data theme diverged from the Liquid baseline"
+    end
+  end
+
+  def test_catppuccin_example_loads_and_renders_truecolor
+    theme = THEME.load(File.expand_path("../examples/themes/catppuccin-mocha.yml", __dir__)).new
+    out = theme.task_success(task: task_info(name: "A::Build", state: :completed, duration: 1234))
+    assert_includes out, "\e[38;2;166;227;161m✔\e[0m", "truecolor success icon"
+    assert_includes out, "\e[38;2;108;112;134m(1.2s)\e[0m", "dim duration fragment"
+  end
+
+  private
+
+  def with_theme_file(content)
+    Tempfile.create(["theme", ".yml"]) do |f|
+      f.write(content)
+      f.flush
+      yield f.path
+    end
+  end
+end
+
+# Config integration: Taski.progress.theme = "path.yml" — validated at
+# assignment, builds through the unchanged Class-contract, renders end to end
+# through Layout::Log (observer events; no task execution involved).
+class TestThemeDeclarativeConfig < Minitest::Test
+  THEME = Taski::Progress::Theme
+
+  def setup
+    Taski.reset_progress_display!
+  end
+
+  def teardown
+    Taski.reset_progress_display!
+  end
+
+  def test_config_accepts_string_path
+    with_theme_file(<<~YAML) do |path|
+      templates:
+        task_start: "GO %{name}"
+    YAML
+      config = Taski::Progress::Config.new
+      config.theme = path
+      assert_operator config.theme, :<=, THEME::Base
+    end
+  end
+
+  def test_config_accepts_pathname
+    with_theme_file(<<~YAML) do |path|
+      templates:
+        task_start: "GO %{name}"
+    YAML
+      config = Taski::Progress::Config.new
+      config.theme = Pathname.new(path)
+      assert_operator config.theme, :<=, THEME::Base
+    end
+  end
+
+  def test_config_raises_load_error_at_assignment_for_bad_path
+    config = Taski::Progress::Config.new
+    assert_raises(THEME::LoadError) { config.theme = "/no/such/theme.yml" }
+    assert_nil config.theme, "a failed assignment must not change the config"
+  end
+
+  def test_config_raises_load_error_at_assignment_for_invalid_theme
+    with_theme_file('templates: {task_start: "%{nope}"}') do |path|
+      config = Taski::Progress::Config.new
+      assert_raises(THEME::LoadError) { config.theme = path }
+    end
+  end
+
+  def test_config_wraps_psych_level_errors_as_load_error
+    # The documented contract: theme= raises Theme::LoadError at assignment —
+    # including Psych errors beyond syntax (aliases, disallowed classes).
+    with_theme_file("colors:\n  green: &g \"x\"\n  dim: *g\n") do |path|
+      config = Taski::Progress::Config.new
+      assert_raises(THEME::LoadError) { config.theme = path }
+    end
+  end
+
+  def test_config_still_accepts_theme_classes
+    config = Taski::Progress::Config.new
+    config.theme = THEME::Detail
+    assert_equal THEME::Detail, config.theme
+  end
+
+  def test_data_theme_renders_end_to_end_through_log_layout
+    with_theme_file(<<~YAML) do |path|
+      templates:
+        task_start:   ">> %{name}"
+        task_success: "OK %{name}%{duration_part}"
+      fragments:
+        duration_part: " [%{duration}]"
+    YAML
+      output = StringIO.new
+      config = Taski::Progress::Config.new
+      config.layout = Taski::Progress::Layout::Log
+      config.theme = path
+      config.output = output
+      display = config.build
+
+      task_class = Class.new
+      task_class.define_singleton_method(:name) { "M::BuildTask" }
+      now = Time.now
+      display.on_start
+      display.on_task_updated(task_class, previous_state: nil, current_state: :running, phase: :run, timestamp: now)
+      display.on_task_updated(task_class, previous_state: :running, current_state: :completed, phase: :run, timestamp: now + 0.1)
+      display.on_stop
+
+      assert_includes output.string, ">> BuildTask"
+      assert_match(/OK BuildTask \[\d+(\.\d+)?ms\]/, output.string)
+    end
+  end
+
+  private
+
+  def with_theme_file(content)
+    Tempfile.create(["theme", ".yml"]) do |f|
+      f.write(content)
+      f.flush
+      yield f.path
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Stacked on #235. Adds **data themes**: progress-display customization from an inert YAML file — scalars, arrays and hashes only (`YAML.safe_load_file`), so **no code runs** and themes can be shared and used without reading them. This is the trust story Liquid was supposed to provide but couldn't (taski themes shipped as Ruby classes, putting the envelope outside the sandbox); data themes move the boundary into the file format itself.

```yaml
# my-theme.yml
schema: 1
extends: detail
colors:
  green: "\e[38;2;166;227;161m"   # truecolor works
templates:
  task_success: "%{icon} %{name}%{duration_part}"
```

```ruby
Taski.progress.theme = "my-theme.yml"   # validated at assignment — Theme::LoadError, never mid-run
```

## Design

- **One vocabulary.** Placeholder names ARE the `Theme::Base` helper names (`%{duration_part}`, `%{icon}`, `%{spinner}`, `%{task_names_part}`, ...) and are computed by the same helper methods. Docs, tests and mental model are shared between Ruby themes and data themes.
- **Real inheritance.** `Theme.load` builds an anonymous class that *actually inherits* from the `extends` theme (`base`/`default`/`plain`/`detail`/`compact` — a closed enum, no constant lookup from file input) with the data layer on top. Declared templates render from format strings; everything undeclared falls through (`super`) to the extends theme **on the same instance** — so declared colors/icons/spinner/formats/fragments apply to fallback-rendered lines too, exactly like a Ruby subclass. A colors-only theme restyles every line.
- **Logic-free by design.** The only-when-present guards stay engine-fixed; arbitrary control flow is the upgrade path to a Ruby theme.
- **Config contract untouched.** The loaded class IS-A `Theme::Base` with zero-arg `.new`; `Config#theme=` additionally accepts String/Pathname.

## Fail-fast validation — a theme that loads cannot fail at render time

- Closed key sets at every level (errors name the offending key AND the allowed set)
- `schema: 1` versioning, checked before anything else (a future-schema file says "unsupported schema version", not "unknown key")
- Type checks; intervals must be finite and within 0.01–60s (`.inf` would kill the spinner/render threads with `RangeError` from `sleep`; tiny values busy-loop the CPU); truncation integers must be positive
- Stray-`%` rejection: strip `/%%|%\{[^}]*\}/`, reject any remaining `%` — `%s`/`%d` would otherwise silently inline the whole payload hash via `Kernel#format`
- A validation render of every declared template/fragment against a fully-populated sample payload — exhaustive because the render payload is uniform
- All Psych-level failures (syntax, aliases, disallowed classes like unquoted dates) wrap as `Theme::LoadError` naming the file
- User data (task names, stdout, error messages) enters `format` only as argument values, never as format strings — no injection surface (adversarially verified)

## Parity proof

The four shipped themes re-encoded as YAML (`test/fixtures/themes/*.yml`) reproduce **all 132 cases of the Liquid-era byte-parity baseline** through the data-theme pipeline.

## Also ships

- `examples/themes/catppuccin-mocha.yml` (truecolor)
- First user-facing theme documentation: GUIDE "Customizing Themes" (Ruby-theme contract + helper API + full placeholder table + the precise trust boundary: a theme cannot execute code, but color values are raw escape strings) and a README teaser
- 51 new tests; suite 822 runs / 0 failures, `rake standard` clean

## Adversarial review

A 39-agent adversarial review (validation bypass / parity-fallback / security / mutation testing / integration) ran before this PR. Security probes confirmed **no code-execution path and no format-string injection**. 24 confirmed findings (heavily overlapping across angles) were folded in:

- **Fallback semantics restructure** (the big one): the original delegation design meant a colors-only theme was a silent no-op and declared spinner frames could desync from fallback-rendered lines. Fixed by making loaded themes real subclasses of the extends theme (verified: the catppuccin example now styles `clean_*`/`group_*` fallback lines).
- `rescue Psych::Exception` (aliases/date scalars no longer escape as raw Psych errors through the documented `LoadError` contract)
- Interval bounds (`.inf`/`1e20`/`1e-4` rejected at load — previously killed the render thread and aborted `on_stop` teardown, leaving the cursor hidden)
- Symbol-keyed `from_hash` input now normalized (previously `{schema: 99}` bypassed the schema gate silently)
- `schema` must be exactly 1; checked before unknown-key validation
- Positive-integer validation for `truncation.list_limit`/`text_max`; deep-frozen definition strings; README example path fixed; `format_duration` 1000ms-boundary mutant killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_(Recreated from #236, which GitHub auto-closed when its base branch `feat/ruby-native-themes` was deleted on merge of #235. Rebased onto master; gates green 822 runs / 0 failures.)_