### PR TITLE
Reset the progress display between top-level executions

### DIFF
--- a/lib/taski/progress/layout/base.rb
+++ b/lib/taski/progress/layout/base.rb
@@ -50,17 +50,22 @@ module Taski
         # === Observer Interface (called by ExecutionFacade) ===
 
         # Event 1: Facade is ready (root task set, output capture available).
-        # Pulls root_task_class and output_capture from context.
         #
-        # root_task_class and the tree build (handle_ready) happen once — a
-        # nested executor must not overwrite the displayed root. The output
-        # capture, however, is re-adopted when the owning execution re-readies
-        # on the SAME facade: the clean phase of run_and_clean tears down the
-        # run-phase output router and builds a fresh one, and the status line
-        # must follow it or it reads the dead run-phase router during clean.
-        # The facade-identity guard means a nested execution (a different
-        # facade) cannot retarget the display's capture, while normal nesting
-        # (which reuses the current facade and router) is a harmless no-op.
+        # The root/tree are adopted once per execution; a re-ready on the SAME
+        # facade (the clean phase of run_and_clean, or a normal nested
+        # execution which reuses the current facade) keeps the displayed
+        # root/tree and only re-adopts the live output router — the clean phase
+        # tears down the run-phase router and builds a fresh one, and the status
+        # line must follow it. A re-ready on a DIFFERENT facade is a nested
+        # executor on its own facade and is ignored.
+        #
+        # A NEW top-level execution always sees @root_task_class == nil here,
+        # because the previous execution cleared it when it stopped (see
+        # on_stop / reset_after_execution) — so it falls through and adopts its
+        # own root/capture. (Doing the reset at stop rather than here is what
+        # makes run_and_clean correct: it calls notify_start BEFORE its first
+        # on_ready, so a reset deferred to on_ready would come too late for the
+        # start line.)
         def on_ready
           @monitor.synchronize do
             if @root_task_class
@@ -104,8 +109,20 @@ module Taski
           end
 
           return unless should_stop
-          handle_stop if was_active
-          flush_queued_messages
+          begin
+            handle_stop if was_active
+            flush_queued_messages
+          ensure
+            # The outermost execution has fully stopped. Clear per-execution
+            # state so the next top-level execution reusing this persistent
+            # display (Config memoizes it) starts fresh, instead of showing this
+            # execution's root and an accumulated task count. In an ensure so a
+            # raising final render or message flush still clears state —
+            # dispatch swallows observer errors, so a leak here would silently
+            # corrupt the next run. Safe: handle_stop already stopped the render
+            # thread.
+            @monitor.synchronize { reset_after_execution }
+          end
         end
 
         # Event 4: Task state transition.
@@ -211,6 +228,28 @@ module Taski
         # Called when facade is ready (root task and output capture available).
         # Override to build tree structure.
         def handle_ready
+          # Default: no-op
+        end
+
+        # Clear all per-execution state when the outermost execution stops, so
+        # the next top-level execution reusing this persistent display adopts
+        # its own root/capture via the normal on_ready path (which keys off
+        # @root_task_class being nil). Subclasses reset their own per-execution
+        # structures via handle_reset.
+        def reset_after_execution
+          @tasks.clear
+          @group_start_times.clear
+          @start_time = nil
+          @root_task_class = nil
+          @display_facade = nil
+          @output_capture = nil
+          @spinner_index = 0
+          handle_reset
+        end
+
+        # Hook for subclasses to reset their own per-execution state (e.g. the
+        # tree node maps, group baselines). Default: no-op.
+        def handle_reset
           # Default: no-op
         end
 

--- a/lib/taski/progress/layout/simple.rb
+++ b/lib/taski/progress/layout/simple.rb
@@ -60,6 +60,13 @@ module Taski
             graph.all_tasks.each { |tc| register_task(tc) }
           end
 
+          # Drop the previous execution's group baselines when a new top-level
+          # execution reuses this display.
+          def handle_reset
+            @group_baselines.clear
+            super
+          end
+
           # Simple layout uses periodic status line updates instead of per-event output
           def handle_task_update(_task_class, _current_state, _phase)
             # No per-event output; status line is updated by render_live

--- a/lib/taski/progress/layout/tree/live.rb
+++ b/lib/taski/progress/layout/tree/live.rb
@@ -27,6 +27,14 @@ module Taski
             build_ready_tree
           end
 
+          # Drop the live-frame line count when an execution ends, so the next
+          # top-level execution's first frame does not erase the previous
+          # execution's final output (clear_previous_output keys off it).
+          def handle_reset
+            @last_line_count = 0
+            super
+          end
+
           # TTY mode: skip per-event output, tree is updated by render_loop
           def handle_task_update(_task_class, _current_state, _phase)
           end

--- a/lib/taski/progress/layout/tree/structure.rb
+++ b/lib/taski/progress/layout/tree/structure.rb
@@ -27,6 +27,13 @@ module Taski
             @node_prefixes = {}
           end
 
+          # Drop the previous execution's tree when a new top-level execution
+          # reuses this display; handle_ready then rebuilds it for the new root.
+          def handle_reset
+            init_tree_structure
+            super
+          end
+
           def build_ready_tree
             graph = context&.dependency_graph
             root = context&.root_task_class

--- a/test/fixtures/display_reset_tasks.rb
+++ b/test/fixtures/display_reset_tasks.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "taski"
+
+# Two independent single-task roots used to prove the progress display resets
+# its per-execution state between sequential top-level executions in the same
+# process (see test_display_reset_between_executions.rb). Each run is one task,
+# so a correct display shows "1/1 tasks" for each — accumulation or a stale
+# root name is the bug.
+module DisplayResetFixtures
+  class FirstRoot < Taski::Task
+    exports :value
+
+    def run
+      @value = :first
+    end
+  end
+
+  class SecondRoot < Taski::Task
+    exports :value
+
+    def run
+      @value = :second
+    end
+  end
+end

--- a/test/test_display_reset_between_executions.rb
+++ b/test/test_display_reset_between_executions.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "stringio"
+require_relative "fixtures/display_reset_tasks"
+
+# The progress display is a persistent singleton (Config#build memoizes it), so
+# it is reused across sequential top-level executions in one process. It must
+# reset its per-execution state (root, task tallies, tree) for each new
+# top-level execution — otherwise the second execution renders the first's
+# root name and an accumulated task count.
+class TestDisplayResetBetweenExecutions < Minitest::Test
+  def setup
+    Taski::Task.reset! if defined?(Taski::Task)
+    Taski::StaticAnalysis::StartDepAnalyzer.clear_cache!
+  end
+
+  def teardown
+    Taski.reset_progress_display!
+  end
+
+  def test_second_top_level_execution_shows_its_own_root_and_count
+    out = StringIO.new
+    Taski.progress.layout = Taski::Progress::Layout::Tree
+    Taski.progress.output = out
+
+    DisplayResetFixtures::FirstRoot.run
+    DisplayResetFixtures::SecondRoot.run
+
+    text = out.string.gsub(/\e\[[0-9;?]*[a-zA-Z]/, "")
+
+    # The second execution must name its OWN root, not the first's (stale).
+    assert_includes text, "Starting SecondRoot",
+      "the second execution must display its own root"
+
+    # Each execution has exactly one task; neither summary may accumulate the
+    # other's tasks.
+    completed = text.lines.grep(/\[TASKI\] Completed:/)
+    assert_equal 2, completed.size, "one completion summary per execution"
+    completed.each do |line|
+      assert_match(%r{1/1 tasks}, line,
+        "each execution counts only its own tasks (no accumulation): #{line.inspect}")
+    end
+  end
+
+  # run_and_clean calls notify_start BEFORE its first on_ready, so the reset
+  # must happen when the previous execution STOPS (not lazily at the next
+  # on_ready) — otherwise the second run_and_clean's tasks accumulate and its
+  # root stays stale. Pinning this separately from plain .run.
+  def test_second_run_and_clean_does_not_accumulate_tasks
+    out = StringIO.new
+    Taski.progress.layout = Taski::Progress::Layout::Tree
+    Taski.progress.output = out
+
+    DisplayResetFixtures::FirstRoot.run_and_clean
+    DisplayResetFixtures::SecondRoot.run_and_clean
+
+    text = out.string.gsub(/\e\[[0-9;?]*[a-zA-Z]/, "")
+
+    # The second execution renders its own task, not the first's.
+    assert_includes text, "SecondRoot"
+    completed = text.lines.grep(/\[TASKI\] Completed:/)
+    assert_equal 2, completed.size
+    completed.each do |line|
+      assert_match(%r{1/1 tasks}, line,
+        "each run_and_clean counts only its own tasks (no accumulation): #{line.inspect}")
+    end
+  end
+
+  # The reset happens at stop: after a top-level execution finishes, the
+  # display holds no leftover task/root state.
+  def test_display_state_is_cleared_after_an_execution_stops
+    Taski.progress.layout = Taski::Progress::Layout::Log
+    Taski.progress.output = StringIO.new
+
+    DisplayResetFixtures::FirstRoot.run
+    display = Taski.progress_display
+
+    refute display.task_registered?(DisplayResetFixtures::FirstRoot),
+      "per-execution task state must be cleared once the execution stops"
+  end
+
+  def test_display_singleton_is_actually_reused_across_executions
+    # Guards the premise: if the display were rebuilt per execution the bug
+    # could not occur and the test above would be vacuous.
+    Taski.progress.layout = Taski::Progress::Layout::Log
+    Taski.progress.output = StringIO.new
+
+    DisplayResetFixtures::FirstRoot.run
+    first = Taski.progress_display
+    DisplayResetFixtures::SecondRoot.run
+    second = Taski.progress_display
+
+    assert_same first, second, "the global progress display is reused across executions"
+  end
+end

--- a/test/test_layout_base.rb
+++ b/test/test_layout_base.rb
@@ -248,16 +248,95 @@ class TestLayoutBase < Minitest::Test
     assert_includes @output.string, "String"
   end
 
-  def test_on_ready_only_sets_root_task_once
+  # A nested executor readies on its own facade WHILE an execution is active
+  # (@nest_level > 0). It must not overwrite the displayed root or rebuild the
+  # tree.
+  def test_nested_on_ready_does_not_overwrite_root
     @layout.context = mock_execution_facade(root_task_class: String)
     @layout.on_ready
+    @layout.on_start # now inside an execution (@nest_level == 1)
 
     @layout.context = mock_execution_facade(root_task_class: Integer)
+    @layout.on_ready # nested ready on a different facade
+
+    assert_equal String, @layout.instance_variable_get(:@root_task_class)
+  end
+
+  # When the outermost execution stops, per-execution state is cleared so the
+  # display does not carry the root/tasks/spinner into the next top-level
+  # execution.
+  def test_on_stop_clears_per_execution_state
+    @layout.context = stub_facade(root: String, capture: :cap_a)
+    @layout.on_ready
+    @layout.on_start
+    leftover = Class.new
+    @layout.on_task_updated(leftover, previous_state: nil, current_state: :pending, phase: :run, timestamp: Time.now)
+    assert @layout.task_registered?(leftover)
+    @layout.instance_variable_set(:@spinner_index, 7)
+
+    @layout.on_stop
+
+    assert_nil @layout.instance_variable_get(:@root_task_class)
+    assert_nil current_output_capture
+    refute @layout.task_registered?(leftover)
+    assert_equal 0, @layout.spinner_index,
+      "the spinner animation must restart from frame 0 for the next execution"
+  end
+
+  # The reset runs in an ensure, so a raising final render (e.g. a broken
+  # terminal) still clears state — otherwise (dispatch swallows observer
+  # errors) a failed render would silently leak this run's root + task count
+  # into the next top-level execution.
+  def test_on_stop_resets_even_when_the_final_render_raises
+    layout = Taski::Progress::Layout::Base.new(output: @output)
+    layout.context = stub_facade(root: String, capture: :cap_a)
+    layout.on_ready
+    layout.on_start
+    tc = Class.new
+    layout.on_task_updated(tc, previous_state: nil, current_state: :pending, phase: :run, timestamp: Time.now)
+    def layout.handle_stop = raise("render boom") # final render fails
+
+    assert_raises(RuntimeError) { layout.on_stop }
+
+    assert_nil layout.instance_variable_get(:@root_task_class),
+      "reset must run from the ensure even when the final render raises"
+    refute layout.task_registered?(tc)
+  end
+
+  # After the first execution stops, a second top-level execution adopts its
+  # own root + capture (the cleared state makes on_ready take the fresh-adopt
+  # path).
+  def test_second_top_level_execution_adopts_its_own_state
+    @layout.context = stub_facade(root: String, capture: :cap_a)
+    @layout.on_ready
+    @layout.on_start
+    @layout.on_stop # first execution fully finishes — state cleared
+
+    @layout.context = stub_facade(root: Integer, capture: :cap_b)
     @layout.on_ready
 
+    assert_equal Integer, @layout.instance_variable_get(:@root_task_class)
+    assert_equal :cap_b, current_output_capture
+  end
+
+  # run_and_clean calls notify_start (raising nest level) BEFORE its first
+  # on_ready, so a second run_and_clean readies at nest_level 1 — it must still
+  # adopt its own state, because the reset already happened when the first
+  # execution stopped (not lazily at on_ready).
+  def test_second_execution_adopts_even_when_readying_at_raised_nest_level
+    @layout.context = stub_facade(root: String, capture: :cap_a)
+    @layout.on_ready
     @layout.on_start
-    assert_includes @output.string, "String"
-    refute_includes @output.string, "Integer"
+    @layout.on_stop # first execution finished — state cleared
+
+    @layout.on_start # run_and_clean's pre-increment, before its first on_ready
+    @layout.context = stub_facade(root: Integer, capture: :cap_b)
+    @layout.on_ready
+
+    assert_equal Integer, @layout.instance_variable_get(:@root_task_class)
+    assert_equal :cap_b, current_output_capture
+  ensure
+    @layout.on_stop
   end
 
   # The clean phase of run_and_clean re-readies on the SAME facade after it
@@ -279,18 +358,19 @@ class TestLayoutBase < Minitest::Test
       "the root task must not change across phases"
   end
 
-  # A nested execution runs on a DIFFERENT facade. It does not own the
-  # display, so a re-ready from it must not retarget the capture (nor rebuild
-  # the tree / overwrite the root — the existing once-guard).
-  def test_on_ready_does_not_retarget_capture_for_a_different_facade
+  # A nested execution on a DIFFERENT facade (active execution, @nest_level > 0)
+  # does not own the display, so it must not retarget the capture nor overwrite
+  # the root.
+  def test_on_ready_does_not_retarget_capture_for_a_nested_different_facade
     @layout.context = stub_facade(root: String, capture: :run_router)
     @layout.on_ready
+    @layout.on_start # inside an execution (@nest_level == 1)
 
     @layout.context = stub_facade(root: Integer, capture: :nested_router)
     @layout.on_ready
 
     assert_equal :run_router, current_output_capture,
-      "a different (nested) facade must not retarget the display's capture"
+      "a nested different facade must not retarget the display's capture"
     assert_equal String, @layout.instance_variable_get(:@root_task_class)
   end
 

--- a/test/test_layout_tree_event.rb
+++ b/test/test_layout_tree_event.rb
@@ -342,6 +342,31 @@ class TestLayoutTreeEventPrefix < Minitest::Test
     ], @layout.render_tree.lines.map(&:chomp)
   end
 
+  # A second top-level execution reuses the persistent display; its tree node
+  # map must be rebuilt for the new root, not retain the previous execution's
+  # nodes (handle_reset re-inits the structure when the first execution stops).
+  def test_tree_node_map_is_rebuilt_for_a_second_execution
+    shared = stub_task_class("Shared")
+    first_root = stub_task_class_with_deps("FirstRoot", [shared])
+    @layout.context = mock_execution_facade(root_task_class: first_root)
+    @layout.on_ready
+    @layout.on_start
+    @layout.on_stop # first execution stops -> tree node map cleared
+
+    second_root = stub_task_class_with_deps("SecondRoot", [shared])
+    @layout.context = mock_execution_facade(root_task_class: second_root)
+    @layout.on_ready
+
+    nodes = @layout.instance_variable_get(:@tree_nodes).keys
+    assert_equal 2, nodes.size
+    assert_includes nodes, second_root
+    assert_includes nodes, shared
+    refute_includes nodes, first_root,
+      "the first execution's root must not leak into the second tree"
+    refute_includes @layout.render_tree, "FirstRoot",
+      "the rendered tree must show only the second execution's tasks"
+  end
+
   private
 
   def stub_task_class(name)

--- a/test/test_layout_tree_live.rb
+++ b/test/test_layout_tree_live.rb
@@ -92,6 +92,24 @@ class TestLayoutTreeLive < Minitest::Test
     assert_includes @output.string, "[TASKI] Failed: 1/1 tasks"
   end
 
+  # @last_line_count must reset when an execution stops, so the next top-level
+  # execution's first live frame does not move the cursor up and erase the
+  # previous execution's final output (clear_previous_output keys off it).
+  def test_last_line_count_is_reset_after_an_execution_stops
+    parent = stub_task_class_with_deps("Parent", [stub_task_class("A"), stub_task_class("B")])
+    @layout.context = mock_execution_facade(root_task_class: parent)
+    @layout.on_ready
+    @layout.on_start
+    # Simulate the render loop having drawn a multi-line frame, so the reset is
+    # actually exercised (otherwise @last_line_count is already 0 and the test
+    # is vacuous).
+    @layout.instance_variable_set(:@last_line_count, 5)
+    @layout.on_stop
+
+    assert_equal 0, @layout.instance_variable_get(:@last_line_count),
+      "the next execution's first frame must not erase the previous execution's final output"
+  end
+
   def test_tree_prefix_for_children
     child1 = stub_task_class("Child1")
     child2 = stub_task_class("Child2")

--- a/test/test_simple_progress_display.rb
+++ b/test/test_simple_progress_display.rb
@@ -66,18 +66,39 @@ class TestSimpleProgressDisplay < Minitest::Test
     assert @display.task_registered?(FixtureTaskA)
   end
 
-  def test_set_root_task_is_idempotent
+  def test_nested_on_ready_does_not_change_the_registered_set
     ctx = mock_execution_facade(root_task_class: FixtureTaskB)
     @display.context = ctx
     @display.on_ready
+    @display.on_start # inside an execution (@nest_level == 1)
 
     ctx2 = mock_execution_facade(root_task_class: FixtureTaskA)
     @display.context = ctx2
-    @display.on_ready # Should be ignored (root already set)
+    @display.on_ready # nested ready — must be ignored
 
-    # Only the first root task's dependencies should be registered
+    # The first root task's graph stays registered
     assert @display.task_registered?(FixtureTaskB)
     assert @display.task_registered?(FixtureTaskA)
+  end
+
+  def test_new_top_level_execution_re_registers_for_its_own_root
+    # FixtureTaskB depends on FixtureTaskA; FixtureTaskA is a leaf.
+    ctx = mock_execution_facade(root_task_class: FixtureTaskB)
+    @display.context = ctx
+    @display.on_ready
+    @display.on_start
+    assert @display.task_registered?(FixtureTaskB)
+    @display.on_stop # first execution fully finishes
+
+    # A second top-level execution rooted at the leaf must reset and register
+    # only its own graph.
+    ctx2 = mock_execution_facade(root_task_class: FixtureTaskA)
+    @display.context = ctx2
+    @display.on_ready
+
+    assert @display.task_registered?(FixtureTaskA)
+    refute @display.task_registered?(FixtureTaskB),
+      "the previous execution's tasks must be cleared for a new top-level run"
   end
 
   def test_start_and_stop_without_tty


### PR DESCRIPTION
## Problem

Surfaced by the #240 adversarial review. The progress display is a persistent singleton (`Config#build` memoizes `@cached_display`), reused across sequential top-level executions in one process. The displayed root was never reset and `@tasks` accumulated — so a second top-level `Task.run` / `run_and_clean` rendered the **first** execution's root name and an **accumulated** task count:

```
[TASKI] Starting FirstRoot      # run #1
[TASKI] Completed: 1/1 tasks
[TASKI] Starting FirstRoot      # run #2: stale root — should be SecondRoot
[TASKI] Completed: 2/2 tasks    # accumulated — should be 1/1
```

Pre-existing; hits any program running ≥2 top-level tasks per process — scripts, test suites, REPLs.

## Fix

Clear per-execution state when the **outermost execution stops** (`on_stop` at `@nest_level == 0`), after the final frame has rendered and `handle_stop` has stopped the render thread. The next top-level execution then sees `@root_task_class == nil` and adopts its own root/capture via the normal `on_ready` path; nested executions stop at `@nest_level > 0` and never trigger the reset.

**Why reset at stop, not lazily at the next `on_ready`:** `run_and_clean` calls `notify_start` *before* its first `on_ready`. A reset deferred to `on_ready` would come too late for the start line and mis-detect the new execution as nested. Resetting at stop sidesteps the ordering and leaves `on_ready` unchanged from #240. *(An earlier draft keyed the reset off `@nest_level` in `on_ready` and was caught during self-review failing exactly the `run_and_clean`×2 case — hence the stop-based approach, pinned by a dedicated test.)*

`reset_after_execution` (run from an **`ensure`**, so a raising final render still clears state — `dispatch` swallows observer errors) clears the base tallies (`@tasks`, `@group_start_times`, `@start_time`), `@root_task_class` / `@display_facade` / `@output_capture`, and `@spinner_index`, then calls a `handle_reset` hook; Tree re-inits its node maps, **Tree::Live** also drops `@last_line_count`, and **Simple** clears its group baselines.

## Tests

- End-to-end through the real executor: two sequential plain runs **and** two sequential `run_and_clean` (each shows its own root and `1/1`, no accumulation); singleton-reused guard; state-cleared-after-stop.
- Component: `on_stop` clears per-execution state incl. spinner index; reset-via-`ensure` when the final render raises; a second execution adopts its own state (incl. readying at a raised nest level); the Tree node map is rebuilt for a second execution; Tree::Live's `@last_line_count` is reset.
- Existing once-guard tests updated to simulate real nesting.

Suite 856 runs / 0 failures, `rake standard` clean. Off master, independent.

## Adversarial review

A fresh 15-agent review of the reset-on-stop design (the earlier review of a discarded `@nest_level` draft was stopped). 4 confirmed findings, all folded: spinner index not reset (LOW); reset skipped if the final render raises → moved into an `ensure` (MED); two coverage gaps (no two-run Tree-node test, no Tree::Live `@last_line_count` test) → tests added and mutation-verified. Refuted: post-run `task_state` returning nil is an intentional, accepted semantics change; `@context` retaining a stale facade is informational; nested/clean unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)